### PR TITLE
Update scripts.cc

### DIFF
--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -43,7 +43,7 @@
 
 namespace fallout {
 
-#define DIR_SEPARATOR '/' 
+#define DIR_SEPARATOR '/'
 #define SCRIPT_LIST_EXTENT_SIZE 16
 
 // SFALL: Increase number of message lists for scripted dialogs.


### PR DESCRIPTION
Updated scripts to search for and load script_x.lst files and load the accompanying scripts, then append them to the scripts 'list'. This allows mods to add scripts without having to add their scripts into scripts.lst

Only tested on macOS so far. Path separators handled like in art.cc, so shouuuld be okay.