### PR TITLE
Fix for Pass Through bug on Use Item On inventory

### DIFF
--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -917,6 +917,13 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
         return;
     }
 
+    // Check if we should block mouse button up events for useOn inventory window
+    if (gBlockMouseUpEvent && (mouseState & MOUSE_EVENT_LEFT_BUTTON_UP) != 0) {
+        // Auto-reset the flag after blocking one event
+        gBlockMouseUpEvent = false;
+        return;
+    }
+
     if ((mouseState & MOUSE_EVENT_RIGHT_BUTTON_DOWN) != 0) {
         if ((mouseState & MOUSE_EVENT_RIGHT_BUTTON_REPEAT) == 0 && (gGameMouseHexCursor->flags & OBJECT_HIDDEN) == 0) {
             gameMouseCycleMode();

--- a/src/input.cc
+++ b/src/input.cc
@@ -98,6 +98,9 @@ static TickerListNode* gTickerListHead;
 // 0x6AC788
 static unsigned int gTickerLastTimestamp;
 
+// global for useItemOn inventory to prevent click through bug
+bool gBlockMouseUpEvent = false;
+
 // 0x4C8A70
 int inputInit(int a1)
 {

--- a/src/input.h
+++ b/src/input.h
@@ -7,6 +7,9 @@ typedef void(TickerProc)();
 
 typedef int(ScreenshotHandler)(int width, int height, unsigned char* buffer, unsigned char* palette);
 
+// global for blocking mouse event in useItemOn inventory screen
+extern bool gBlockMouseUpEvent;
+
 int inputInit(int a1);
 void inputExit();
 int inputGetInput();

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -2746,6 +2746,8 @@ void inventoryOpenUseItemOn(Object* targetObj)
                             } else {
                                 _action_use_an_item_on_object(gDude, targetObj, inventoryItem->item);
                             }
+                            // fix for click through bug
+                            gBlockMouseUpEvent = true;
                             keyCode = KEY_ESCAPE;
                         } else {
                             keyCode = -1;


### PR DESCRIPTION
Uses a global to prevent the registering of a BUTTON_UP on the UseItemOn inventory, to prevent the unused click being used on the object below the clicked item in the inventory.
