### PR TITLE
Add StrictVanilla config and mass-highlight changes

### DIFF
--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -538,22 +538,22 @@ bool HandleHoldToHighlight()
 {
     static bool wasHighlighting = false;
     static bool keyProcessed = false;
-    
+
     // Check if 'H' is currently pressed (including repeat state)
     int hKeyScancode = SDL_SCANCODE_H;
     bool hKeyPressed = false;
-    
+
     if (hKeyScancode >= 0 && hKeyScancode < SDL_NUM_SCANCODES) {
         int keyState = gPressedPhysicalKeys[hKeyScancode];
         hKeyPressed = (keyState == KEY_STATE_DOWN || keyState == KEY_STATE_REPEAT);
     }
-    
+
     if (hKeyPressed && !keyProcessed) {
         keyProcessed = true;
-        
+
         if (!wasHighlighting) {
             wasHighlighting = true;
-            
+
             // Highlight all items
             Object* obj = objectFindFirstAtElevation(gElevation);
             while (obj != nullptr) {
@@ -563,41 +563,40 @@ bool HandleHoldToHighlight()
                 }
                 obj = objectFindNextAtElevation();
             }
-            
+
             tileWindowRefresh();
         }
-    }
-    else if (!hKeyPressed && keyProcessed) {
+    } else if (!hKeyPressed && keyProcessed) {
         keyProcessed = false;
-        
+
         if (wasHighlighting) {
             wasHighlighting = false;
 
             // Get the item currently under the cursor (if any)
             Object* pointedObject = gameMouseGetObjectUnderCursor(-1, true, gElevation);
-            
+
             if (pointedObject != nullptr && FID_TYPE(pointedObject->fid) == OBJ_TYPE_ITEM) {
                 // set object under cursor to the highlight item, in case it was not by pre-mass highlighting
                 gGameMouseHighlightedItem = pointedObject;
             }
-            
+
             // Clear all item outlines
             Object* obj = objectFindFirstAtElevation(gElevation);
             while (obj != nullptr) {
-                    // Don't clear mouse-highlighted item
-                    if (obj != gGameMouseHighlightedItem){
-                        if (FID_TYPE(obj->fid) == OBJ_TYPE_ITEM) {
-                            Rect tmp;
-                            objectClearOutline(obj, &tmp);
-                        }
+                // Don't clear mouse-highlighted item
+                if (obj != gGameMouseHighlightedItem) {
+                    if (FID_TYPE(obj->fid) == OBJ_TYPE_ITEM) {
+                        Rect tmp;
+                        objectClearOutline(obj, &tmp);
                     }
-                    obj = objectFindNextAtElevation();
+                }
+                obj = objectFindNextAtElevation();
             }
-            
+
             tileWindowRefresh();
         }
     }
-    
+
     return wasHighlighting;
 }
 
@@ -747,7 +746,7 @@ void gameMouseRefresh()
     // hold-to-highlight function here, to prevent out of window highlighting.
     bool isMassHighlighting = false;
     // turn off if strictVanilla is being enforced or highlighting not enabled
-    if (!strictVanilla && gGameMouseItemHighlightEnabled){
+    if (!strictVanilla && gGameMouseItemHighlightEnabled) {
         isMassHighlighting = HandleHoldToHighlight();
     }
 
@@ -797,7 +796,7 @@ void gameMouseRefresh()
                     switch (FID_TYPE(pointedObject->fid)) {
                     case OBJ_TYPE_ITEM:
                         primaryAction = GAME_MOUSE_ACTION_MENU_ITEM_USE;
-                        
+
                         // Don't set individual outline if we're mass highlighting
                         if (gGameMouseItemHighlightEnabled && !isMassHighlighting) {
                             Rect tmp;

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -340,6 +340,9 @@ static Object* gGameMousePointedObject;
 // used for y-offset in trade/barter screen sort context meun
 static int gGameMouseActionMenuYAdjustment = 0;
 
+// used for setting strict vanilla behavior
+static bool strictVanilla = false;
+
 static int _gmouse_get_click_to_scroll();
 static void _gmouse_3d_enable_modes();
 static int gameMouseSetBouncingCursorFid(int fid);
@@ -376,6 +379,9 @@ int gameMouseInit()
     if (gameMouseObjectsInit() != 0) {
         return -1;
     }
+
+    // turn strict vanilla mode on or off from conifg
+    configGetBool(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_STRICT_VANILLA, &strictVanilla);
 
     gGameMouseInitialized = true;
     _gmouse_enabled = 1;
@@ -527,6 +533,74 @@ int _gmouse_is_scrolling()
     return v1;
 }
 
+// Function to handle hold-to-highlight functionality
+bool HandleHoldToHighlight()
+{
+    static bool wasHighlighting = false;
+    static bool keyProcessed = false;
+    
+    // Check if 'H' is currently pressed (including repeat state)
+    int hKeyScancode = SDL_SCANCODE_H;
+    bool hKeyPressed = false;
+    
+    if (hKeyScancode >= 0 && hKeyScancode < SDL_NUM_SCANCODES) {
+        int keyState = gPressedPhysicalKeys[hKeyScancode];
+        hKeyPressed = (keyState == KEY_STATE_DOWN || keyState == KEY_STATE_REPEAT);
+    }
+    
+    if (hKeyPressed && !keyProcessed) {
+        keyProcessed = true;
+        
+        if (!wasHighlighting) {
+            wasHighlighting = true;
+            
+            // Highlight all items
+            Object* obj = objectFindFirstAtElevation(gElevation);
+            while (obj != nullptr) {
+                if (FID_TYPE(obj->fid) == OBJ_TYPE_ITEM) {
+                    Rect tmp;
+                    objectSetOutline(obj, OUTLINE_TYPE_ITEM, &tmp);
+                }
+                obj = objectFindNextAtElevation();
+            }
+            
+            tileWindowRefresh();
+        }
+    }
+    else if (!hKeyPressed && keyProcessed) {
+        keyProcessed = false;
+        
+        if (wasHighlighting) {
+            wasHighlighting = false;
+
+            // Get the item currently under the cursor (if any)
+            Object* pointedObject = gameMouseGetObjectUnderCursor(-1, true, gElevation);
+            
+            if (pointedObject != nullptr && FID_TYPE(pointedObject->fid) == OBJ_TYPE_ITEM) {
+                // set object under cursor to the highlight item, in case it was not by pre-mass highlighting
+                gGameMouseHighlightedItem = pointedObject;
+            }
+            
+            // Clear all item outlines
+            Object* obj = objectFindFirstAtElevation(gElevation);
+            while (obj != nullptr) {
+                    // Don't clear mouse-highlighted item
+                    if (obj != gGameMouseHighlightedItem){
+                        if (FID_TYPE(obj->fid) == OBJ_TYPE_ITEM) {
+                            Rect tmp;
+                            objectClearOutline(obj, &tmp);
+                        }
+                    }
+                    obj = objectFindNextAtElevation();
+            }
+            
+            tileWindowRefresh();
+        }
+    }
+    
+    return wasHighlighting;
+}
+
 // 0x44B684
 void gameMouseRefresh()
 {
@@ -670,6 +744,13 @@ void gameMouseRefresh()
         return;
     }
 
+    // hold-to-highlight function here, to prevent out of window highlighting.
+    bool isMassHighlighting = false;
+    // turn off if strictVanilla is being enforced or highlighting not enabled
+    if (!strictVanilla && gGameMouseItemHighlightEnabled){
+        isMassHighlighting = HandleHoldToHighlight();
+    }
+
     // NOTE: Strange set of conditions and jumps. Not sure about this one.
     switch (gGameMouseCursor) {
     case MOUSE_CURSOR_NONE:
@@ -716,7 +797,9 @@ void gameMouseRefresh()
                     switch (FID_TYPE(pointedObject->fid)) {
                     case OBJ_TYPE_ITEM:
                         primaryAction = GAME_MOUSE_ACTION_MENU_ITEM_USE;
-                        if (gGameMouseItemHighlightEnabled) {
+                        
+                        // Don't set individual outline if we're mass highlighting
+                        if (gGameMouseItemHighlightEnabled && !isMassHighlighting) {
                             Rect tmp;
                             if (objectSetOutline(pointedObject, OUTLINE_TYPE_ITEM, &tmp) == 0) {
                                 tileWindowRefreshRect(&tmp, gElevation);

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -539,16 +539,16 @@ bool HandleHoldToHighlight()
     static bool wasHighlighting = false;
     static bool keyProcessed = false;
 
-    // Check if 'H' is currently pressed (including repeat state)
-    int hKeyScancode = SDL_SCANCODE_H;
-    bool hKeyPressed = false;
+    // Check if 'Left Shift' is currently pressed (including repeat state)
+    int shiftKeyScancode = SDL_SCANCODE_LSHIFT;
+    bool shiftKeyPressed = false;
 
-    if (hKeyScancode >= 0 && hKeyScancode < SDL_NUM_SCANCODES) {
-        int keyState = gPressedPhysicalKeys[hKeyScancode];
-        hKeyPressed = (keyState == KEY_STATE_DOWN || keyState == KEY_STATE_REPEAT);
+    if (shiftKeyScancode >= 0 && shiftKeyScancode < SDL_NUM_SCANCODES) {
+        int keyState = gPressedPhysicalKeys[shiftKeyScancode];
+        shiftKeyPressed = (keyState == KEY_STATE_DOWN || keyState == KEY_STATE_REPEAT);
     }
 
-    if (hKeyPressed && !keyProcessed) {
+    if (shiftKeyPressed && !keyProcessed) {
         keyProcessed = true;
 
         if (!wasHighlighting) {
@@ -566,7 +566,7 @@ bool HandleHoldToHighlight()
 
             tileWindowRefresh();
         }
-    } else if (!hKeyPressed && keyProcessed) {
+    } else if (!shiftKeyPressed && keyProcessed) {
         keyProcessed = false;
 
         if (wasHighlighting) {

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -564,6 +564,9 @@ static int gBarterInsultIncrease = 0;
 // used to switch enhancedBarter on/off from config
 static bool enhancedBarter = false;
 
+// used for setting strict vanilla behavior from config
+static bool strictVanilla = false;
+
 // Rotation tracking for quick-click sort
 static Object* _last_quick_sorted_object;
 static int _next_quick_sort_type = GAME_MOUSE_ACTION_MENU_ITEM_SORT_DEFAULT;
@@ -809,6 +812,8 @@ static bool _setup_inventory(int inventoryWindowType)
 
     // turn enhanced barter on or off from conifg
     configGetBool(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_ENHANCED_BARTER, &enhancedBarter);
+    // turn strict vanilla mode on or off from conifg
+    configGetBool(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_STRICT_VANILLA, &strictVanilla);
 
     if (inventoryWindowType <= INVENTORY_WINDOW_TYPE_LOOT) {
         const InventoryWindowDescription* windowDescription = &(gInventoryWindowDescriptions[inventoryWindowType]);
@@ -5919,7 +5924,12 @@ int inventoryOpenLooting(Object* looter, Object* target)
                 int currentWeight = objectGetInventoryWeight(looter);
                 int newInventoryWeight = objectGetInventoryWeight(target);
                 if (newInventoryWeight <= maxCarryWeight - currentWeight) {
-                    itemMoveAll(target, looter);
+                    itemMoveAll(target, looter); // items moved
+                    if(!strictVanilla){
+                        soundPlayFile("ib1p1xx1");
+                        break;  // Exit loop early and close window for convenience
+                    }
+                    // display changes but do not exit
                     _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, INVENTORY_WINDOW_TYPE_LOOT);
                     _display_inventory(_stack_offset[_curr_stack], -1, INVENTORY_WINDOW_TYPE_LOOT);
                 } else {
@@ -7466,6 +7476,13 @@ static int inventoryQuantitySelect(int inventoryWindowType, Object* item, int ma
             isTyping = false;
             value = max;
             _draw_amount(value, inventoryWindowType);
+            
+            if(!strictVanilla){
+                // For move items, treat "All" as immediate confirmation
+                if (inventoryWindowType == INVENTORY_WINDOW_TYPE_MOVE_ITEMS) {
+                    break;  // Exit loop to return the value
+                }
+            }
         } else if (keyCode == 6000) {
             isTyping = false;
             if (value < max) {

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -5925,9 +5925,9 @@ int inventoryOpenLooting(Object* looter, Object* target)
                 int newInventoryWeight = objectGetInventoryWeight(target);
                 if (newInventoryWeight <= maxCarryWeight - currentWeight) {
                     itemMoveAll(target, looter); // items moved
-                    if(!strictVanilla){
+                    if (!strictVanilla) {
                         soundPlayFile("ib1p1xx1");
-                        break;  // Exit loop early and close window for convenience
+                        break; // Exit loop early and close window for convenience
                     }
                     // display changes but do not exit
                     _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, INVENTORY_WINDOW_TYPE_LOOT);
@@ -7476,11 +7476,11 @@ static int inventoryQuantitySelect(int inventoryWindowType, Object* item, int ma
             isTyping = false;
             value = max;
             _draw_amount(value, inventoryWindowType);
-            
-            if(!strictVanilla){
+
+            if (!strictVanilla) {
                 // For move items, treat "All" as immediate confirmation
                 if (inventoryWindowType == INVENTORY_WINDOW_TYPE_MOVE_ITEMS) {
-                    break;  // Exit loop to return the value
+                    break; // Exit loop to return the value
                 }
             }
         } else if (keyCode == 6000) {

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -200,6 +200,7 @@ static void settingsFromConfig()
     settingsRead(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_GAPLESS_MUSIC, settings.sfall_misc.gapless_music);
     settingsRead(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_WORLDMAP_TRAIL_MARKERS, settings.sfall_misc.worldmap_trail_markers);
     settingsRead(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_ENHANCED_BARTER, settings.sfall_misc.enhanced_barter);
+    settingsRead(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_STRICT_VANILLA, settings.sfall_misc.strict_vanilla);
     settingsRead(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_IFACE_BAR_MODE, settings.sfall_misc.iface_bar_mode);
     settingsRead(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_IFACE_BAR_WIDTH, settings.sfall_misc.iface_bar_width);
     settingsRead(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_IFACE_BAR_SIDE_ART, settings.sfall_misc.iface_bar_side_art);
@@ -368,6 +369,7 @@ static void settingsToConfig()
     settingsWrite(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_GAPLESS_MUSIC, settings.sfall_misc.gapless_music);
     settingsWrite(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_WORLDMAP_TRAIL_MARKERS, settings.sfall_misc.worldmap_trail_markers);
     settingsWrite(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_ENHANCED_BARTER, settings.sfall_misc.enhanced_barter);
+    settingsWrite(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_STRICT_VANILLA, settings.sfall_misc.strict_vanilla);
     settingsWrite(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_IFACE_BAR_MODE, settings.sfall_misc.iface_bar_mode);
     settingsWrite(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_IFACE_BAR_WIDTH, settings.sfall_misc.iface_bar_width);
     settingsWrite(SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_IFACE_BAR_SIDE_ART, settings.sfall_misc.iface_bar_side_art);

--- a/src/settings.h
+++ b/src/settings.h
@@ -183,6 +183,7 @@ struct SfallMiscSettings {
     int gapless_music = 0;
     int worldmap_trail_markers = 0;
     bool enhanced_barter = false;
+    bool strict_vanilla = false;
     bool iface_bar_mode = true;
     int iface_bar_width = 800;
     int iface_bar_side_art = 0;

--- a/src/sfall_config.cc
+++ b/src/sfall_config.cc
@@ -71,6 +71,7 @@ bool sfallConfigInit(int argc, char** argv)
     configSetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_GAPLESS_MUSIC, 0);
     configSetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_WORLDMAP_TRAIL_MARKERS, 0);
     configSetBool(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_ENHANCED_BARTER, 0);
+    configSetBool(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_STRICT_VANILLA, 0);
 
     configSetBool(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_IFACE_BAR_MODE, true);
     configSetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_IFACE_BAR_WIDTH, 800);

--- a/src/sfall_config.h
+++ b/src/sfall_config.h
@@ -83,6 +83,7 @@ namespace fallout {
 #define SFALL_CONFIG_GAPLESS_MUSIC "GaplessMusic" // note: this isn't an sfall config
 #define SFALL_CONFIG_WORLDMAP_TRAIL_MARKERS "WorldMapTravelMarkers"
 #define SFALL_CONFIG_ENHANCED_BARTER "EnhancedBarter"
+#define SFALL_CONFIG_STRICT_VANILLA "StrictVanilla"
 
 // temp for iface bar from f2_res.ini
 #define SFALL_CONFIG_IFACE_BAR_MODE "IFACE_BAR_MODE"


### PR DESCRIPTION
Introduce a new StrictVanilla configuration option and wire it through config, settings and headers. Implement hold-to-highlight behavior in game_mouse (HandleHoldToHighlight) and gate mass/highlight and per-item outline logic by strictVanilla. Adjust inventory behavior when strictVanilla is off: play loot-all sound and close early after moving all items, and treat "All" in move-items quantity select as immediate confirmation. Update sfall_config defaults, settings read/write, and add SFALL_CONFIG_STRICT_VANILLA macro.