### PR TITLE
wip: Sliding effect when walking over certain tiles

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -39,6 +39,10 @@ namespace fallout {
 
 #define MAX_KNOCKDOWN_DISTANCE 20
 
+#define ICE_SLIDE_CHANCE_PERCENT 33
+#define ICE_SLIDE_DISTANCE_MIN 3
+#define ICE_SLIDE_DISTANCE_MAX 12
+
 typedef enum ScienceRepairTargetType {
     SCIENCE_REPAIR_TARGET_TYPE_DEFAULT,
     SCIENCE_REPAIR_TARGET_TYPE_DUDE,
@@ -75,7 +79,7 @@ static const int gMaximumBloodDeathAnimations[DAMAGE_TYPE_COUNT] = {
 
 // Note: some of these are callbacks that always take two Object*, but may not use them.
 // Ignored parameters are marked with underscores.
-static int actionKnockdown(Object* obj, int* anim, int maxDistance, int rotation, int delay);
+static int critterKnockdownSlide(Object* obj, int* anim, int maxDistance, int rotation, int delay);
 static int _action_blood(Object* obj, int anim, int delay);
 static int _pick_death(Object* attacker, Object* defender, Object* weapon, int damage, int attackerAnimation, bool hitFromFront);
 static int _check_death(Object* obj, int anim, int minViolenceLevel, bool hitFromFront);
@@ -101,7 +105,7 @@ static int _compute_dmg_damage(int min, int max, Object* obj, int* knockbackDist
 static int hideProjectile(void* _, void* projectile);
 
 // 0x410468
-int actionKnockdown(Object* obj, int* anim, int maxDistance, int rotation, int delay)
+static int critterKnockdownSlide(Object* obj, int* anim, int maxDistance, int rotation, int delay)
 {
     if (critterFlagCheck(obj->pid, CRITTER_NO_KNOCKBACK)) {
         return -1;
@@ -153,6 +157,74 @@ int actionKnockdown(Object* obj, int* anim, int maxDistance, int rotation, int d
     }
 
     return tile;
+}
+
+static int actionKnockdown(Object* obj, int* anim, int maxDistance, int rotation, int delay)
+{
+    return critterKnockdownSlide(obj, anim, maxDistance, rotation, delay);
+}
+
+void actionTileWalkIceSlide(Object* obj, int fromTile, int toTile)
+{
+    if (obj == nullptr || obj != gDude) {
+        return;
+    }
+
+    if (FID_TYPE(obj->fid) != OBJ_TYPE_CRITTER || critterIsDead(obj)) {
+        return;
+    }
+
+    if (critterFlagCheck(obj->pid, CRITTER_NO_KNOCKBACK)) {
+        return;
+    }
+
+    if ((obj->flags & OBJECT_MULTIHEX) != 0) {
+        return;
+    }
+
+    if (isInCombat()) {
+        return;
+    }
+
+    int frmIdx = _square[obj->elevation]->field_0[toTile] & 0xFFF;
+    int fid = buildFid(OBJ_TYPE_TILE, frmIdx, 0, 0, 0);
+
+    Proto* tileProto;
+    if (protoFindTileProtoForFloorFid(fid, &tileProto) != 0) {
+        return;
+    }
+
+    if ((tileProto->tile.extendedFlags & PROTO_TILE_EXT_FLAG_ICE_SLIDE) == 0) {
+        return;
+    }
+
+    if (randomBetween(0, 99) >= ICE_SLIDE_CHANCE_PERCENT) {
+        return;
+    }
+
+    int distance = randomBetween(ICE_SLIDE_DISTANCE_MIN, ICE_SLIDE_DISTANCE_MAX);
+    if (distance > MAX_KNOCKDOWN_DISTANCE) {
+        distance = MAX_KNOCKDOWN_DISTANCE;
+    }
+
+    int slideRotation = tileGetRotationTo(fromTile, toTile);
+
+    if (reg_anim_clear(obj) == -2) {
+        return;
+    }
+
+    reg_anim_begin(ANIMATION_REQUEST_RESERVED);
+
+    int anim = ANIM_FALL_FRONT;
+    critterKnockdownSlide(obj, &anim, distance, slideRotation, 0);
+
+    if (anim == ANIM_FALL_BACK) {
+        animationRegisterAnimate(obj, ANIM_BACK_TO_STANDING, -1);
+    } else {
+        animationRegisterAnimate(obj, ANIM_PRONE_TO_STANDING, -1);
+    }
+
+    reg_anim_end();
 }
 
 // 0x410568

--- a/src/actions.h
+++ b/src/actions.h
@@ -21,6 +21,7 @@ bool _action_explode_running();
 int actionExplode(int tile, int elevation, int minDamage, int maxDamage, Object* sourceObj, bool animate);
 int actionTalk(Object* obj, Object* critter);
 void actionDamage(int tile, int elevation, int minDamage, int maxDamage, int damageType, bool animated, bool bypassArmor);
+void actionTileWalkIceSlide(Object* obj, int fromTile, int toTile);
 bool actionCheckPush(Object* obj, Object* target);
 int actionPush(Object* obj, Object* target);
 int _action_can_talk_to(Object* obj, Object* critter);

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "actions.h"
 #include "art.h"
 #include "color.h"
 #include "combat.h"
@@ -3012,6 +3013,7 @@ void _object_animate()
                 _object_move(index);
                 if (savedTile != object->tile) {
                     scriptsExecSpatialProc(object, object->tile, object->elevation);
+                    actionTileWalkIceSlide(object, savedTile, object->tile);
                 }
             }
             continue;

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -2473,6 +2473,40 @@ int proto_max_id(int type)
     return _protoLists[type].max_entries_num;
 }
 
+int protoFindTileProtoForFloorFid(int fid, Proto** protoOut)
+{
+    *protoOut = nullptr;
+
+    ProtoList* list = &_protoLists[OBJ_TYPE_TILE];
+    for (int num = 1; num < list->max_entries_num; num++) {
+        int pid = (OBJ_TYPE_TILE << 24) | num;
+        Proto* proto;
+        if (protoGetProto(pid, &proto) == -1) {
+            continue;
+        }
+        if (proto->tile.fid == fid) {
+            *protoOut = proto;
+            return 0;
+        }
+    }
+
+    for (int i = 0; i < _mod_proto_entries_size; i++) {
+        if (_mod_proto_entries[i].type != OBJ_TYPE_TILE) {
+            continue;
+        }
+        Proto* proto;
+        if (protoGetProto(_mod_proto_entries[i].pid, &proto) == -1) {
+            continue;
+        }
+        if (proto->tile.fid == fid) {
+            *protoOut = proto;
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
 // 0x4A1B30
 int _proto_save_pid(int pid)
 {

--- a/src/proto.h
+++ b/src/proto.h
@@ -175,6 +175,7 @@ void _proto_remove_all();
 int protoGetProto(int pid, Proto** protoPtr);
 int _ResetPlayer();
 int proto_max_id(int type);
+int protoFindTileProtoForFloorFid(int fid, Proto** protoOut);
 
 static bool isExitGridPid(int pid)
 {

--- a/src/proto_types.h
+++ b/src/proto_types.h
@@ -440,6 +440,11 @@ typedef struct WallProto {
     int material; // material
 } WallProto;
 
+// Bits for `TileProto.extendedFlags` (avoid overlapping shared PROTO_EXT_FLAG_* used by tiles).
+typedef enum TileProtoExtendedFlags {
+    PROTO_TILE_EXT_FLAG_ICE_SLIDE = 0x10000,
+} TileProtoExtendedFlags;
+
 typedef struct TileProto {
     int pid; // id
     int messageId; // message_num


### PR DESCRIPTION
### Description

I was asked by one of my teammates about the possibility of making new types of tiles that have effects similar to the acid damage effect caused by radioactive goo tiles in Fallout 2. In this case, we imagined sliding on an icy tile using the effect caused by sledgehammers in combat (actionKnockdown). After consulting my preferred AI model, it became apparent this would be difficult to handle by loading in through the mod loader and takes engine work.

This is a prototype and for deployment should probably be extended to support multiple types of tile effects.

### Reproduction Steps and Savefile (if available)

N/A

### Screenshots

N/A

