### PR TITLE
Minimap Fix

### DIFF
--- a/src/automap.cc
+++ b/src/automap.cc
@@ -293,6 +293,8 @@ static bool gIsoWasEnabled = false;
 // 0x56D2A0
 static AutomapEntry gAutomapEntry;
 
+static bool gAutomapShouldReopenAfterCombat = false;
+
 // Button IDs for minimap toggles
 static int gDetailsButton = -1;
 static int gZoomButton = -1;
@@ -671,6 +673,11 @@ static int automapScreenToTile(int relX, int relY, int playerTile, int winWidth,
  */
 void automapShow(bool isInGame, bool isUsingScanner)
 {
+    // Block minimap from opening during combat
+    if (!settings.enhancements.strict_vanilla && settings.enhancements.minimap && isInCombat()) {
+        return;
+    }
+
     if (!settings.enhancements.strict_vanilla && settings.enhancements.minimap && gAutomapWindowOpen) {
         // Minimap already open - optionally bring to front
         return;
@@ -2061,6 +2068,11 @@ void automapClose()
 {
     if (!gAutomapWindowOpen) return;
 
+    // If we are closing because combat started, set to reopen later
+    if (isInCombat()) {
+        gAutomapShouldReopenAfterCombat = true;
+    }
+
     windowDestroy(gAutomapWindow);
     for (int i = 0; i < AUTOMAP_FRM_COUNT; i++) {
         gAutomapFrmImages[i].unlock();
@@ -2077,6 +2089,15 @@ void automapClose()
     gDetailsButton = -1;
     gZoomButton = -1;
     gProjectionButton = -1;
+}
+
+void automapNotifyCombatEnded()
+{
+    if (gAutomapShouldReopenAfterCombat) {
+        gAutomapShouldReopenAfterCombat = false;
+        // "In game" is always true for minimap, scanner flag is stored in gAutomapFlags
+        automapShow(true, (gAutomapFlags & AUTOMAP_WITH_SCANNER) != 0);
+    }
 }
 
 static void automapUpdateButtonStates(bool playsound)

--- a/src/automap.h
+++ b/src/automap.h
@@ -64,6 +64,7 @@ bool automapIsOpen();
 bool automapHandleKey(int keyCode);
 void automapUpdate();
 void automapClose();
+void automapNotifyCombatEnded();
 
 } // namespace fallout
 

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -7,6 +7,7 @@
 #include "actions.h"
 #include "animation.h"
 #include "art.h"
+#include "automap.h"
 #include "color.h"
 #include "combat_ai.h"
 #include "critter.h"
@@ -2637,6 +2638,11 @@ static void _combat_begin(Object* attacker)
 
         gCombatState |= COMBAT_STATE_0x01;
 
+        // Close minimap if it's open
+        if (!settings.enhancements.strict_vanilla && settings.enhancements.minimap) {
+            automapClose();
+        }
+
         tileWindowRefresh();
         gameUiDisable(0);
         gameMouseSetCursor(MOUSE_CURSOR_WAIT_WATCH);
@@ -2872,6 +2878,9 @@ static void _combat_over()
         queueRemoveEventsByType(gDude, EVENT_TYPE_KNOCKOUT);
         knockoutEventProcess(gDude, nullptr);
     }
+
+    // notify automap(minimap) to reopen if needed
+    automapNotifyCombatEnded();
 }
 
 // 0x422194


### PR DESCRIPTION
This sets the minimap to close when combat starts, and reopen when combat ends.

This may need to be a temp solution - original automap *can* be opened in combat, but must be closed again to continue. This allows players to use the automap to view combat situation potentially, particularly if the 'scanner' is installed.

With the minimap being disabled for combat, this feature is lost. So may need to rethink.

Fixes #64 