### PR TITLE
Head Override

### DIFF
--- a/src/art.cc
+++ b/src/art.cc
@@ -73,7 +73,7 @@ static int gHeadBgGvarMappingCount = 0;
 static struct {
     char script[64];
     char head[64];
-    int bgGvar;   // -1 = none
+    int bgGvar; // -1 = none
 } scriptMaps[MAX_SCRIPT_MAPS];
 static int scriptMapCount = 0;
 
@@ -224,18 +224,20 @@ int getHeadBgGvarOverride(int pid)
     return -1;
 }
 
-static int findScriptMap(const char* script) {
+static int findScriptMap(const char* script)
+{
     for (int i = 0; i < scriptMapCount; i++)
         if (compat_stricmp(scriptMaps[i].script, script) == 0)
             return i;
     return -1;
 }
 
-static void addScriptMap(const char* script, const char* head, int bgGvar) {
+static void addScriptMap(const char* script, const char* head, int bgGvar)
+{
     int idx = findScriptMap(script);
     if (idx != -1) {
         // Update existing entry (e.g., if same script appears again)
-        strncpy(scriptMaps[idx].head, head, sizeof(scriptMaps[0].head)-1);
+        strncpy(scriptMaps[idx].head, head, sizeof(scriptMaps[0].head) - 1);
         scriptMaps[idx].bgGvar = bgGvar;
         return;
     }
@@ -243,18 +245,20 @@ static void addScriptMap(const char* script, const char* head, int bgGvar) {
         debugPrint("WARNING: Script mapping table full\n");
         return;
     }
-    strncpy(scriptMaps[scriptMapCount].script, script, sizeof(scriptMaps[0].script)-1);
-    strncpy(scriptMaps[scriptMapCount].head, head, sizeof(scriptMaps[0].head)-1);
+    strncpy(scriptMaps[scriptMapCount].script, script, sizeof(scriptMaps[0].script) - 1);
+    strncpy(scriptMaps[scriptMapCount].head, head, sizeof(scriptMaps[0].head) - 1);
     scriptMaps[scriptMapCount].bgGvar = bgGvar;
     scriptMapCount++;
 }
 
-const char* getHeadForScript(const char* script) {
+const char* getHeadForScript(const char* script)
+{
     int idx = findScriptMap(script);
     return (idx != -1) ? scriptMaps[idx].head : nullptr;
 }
 
-int getBgGvarForScript(const char* script) {
+int getBgGvarForScript(const char* script)
+{
     int idx = findScriptMap(script);
     return (idx != -1) ? scriptMaps[idx].bgGvar : -1;
 }
@@ -1391,20 +1395,26 @@ static void artLoadModHeadData(ArtListDescription* desc)
                 rest++;
 
             int current_pid = -1;
-            char current_script[64] = {0};
+            char current_script[64] = { 0 };
             bool have_script = false;
 
             while (*rest) {
-                while (*rest && isspace(*rest)) rest++;
+                while (*rest && isspace(*rest))
+                    rest++;
                 if (!*rest) break;
 
                 char* eq = strchr(rest, '=');
-                if (!eq) { while (*rest && !isspace(*rest)) rest++; continue; }
+                if (!eq) {
+                    while (*rest && !isspace(*rest))
+                        rest++;
+                    continue;
+                }
 
                 // Extract key
                 char* key_start = rest;
                 char* key_end = eq;
-                while (key_end > key_start && isspace(*(key_end-1))) key_end--;
+                while (key_end > key_start && isspace(*(key_end - 1)))
+                    key_end--;
                 size_t klen = key_end - key_start;
                 char key[64];
                 strncpy(key, key_start, klen);
@@ -1412,9 +1422,11 @@ static void artLoadModHeadData(ArtListDescription* desc)
 
                 // Move to value
                 rest = eq + 1;
-                while (*rest && isspace(*rest)) rest++;
+                while (*rest && isspace(*rest))
+                    rest++;
                 char* val_start = rest;
-                while (*rest && !isspace(*rest)) rest++;
+                while (*rest && !isspace(*rest))
+                    rest++;
                 char saved = *rest;
                 *rest = '\0';
 
@@ -1423,8 +1435,8 @@ static void artLoadModHeadData(ArtListDescription* desc)
                     have_script = false;
                     addHeadPidMapping(current_pid, filename);
                 } else if (strcmp(key, "npc_script") == 0) {
-                    strncpy(current_script, val_start, sizeof(current_script)-1);
-                    current_script[sizeof(current_script)-1] = '\0';
+                    strncpy(current_script, val_start, sizeof(current_script) - 1);
+                    current_script[sizeof(current_script) - 1] = '\0';
                     have_script = true;
                     current_pid = -1;
                     // Add script mapping (bgGvar will be updated later if present)

--- a/src/art.cc
+++ b/src/art.cc
@@ -1327,7 +1327,7 @@ static void artLoadModHeadData(ArtListDescription* desc)
                 if (!*rest) break;
 
                 // Check for "npc_pid=" token (case-insensitive)
-                if (strncasecmp(rest, "npc_pid=", 8) == 0) {
+                if (strncmp(rest, "npc_pid=", 8) == 0) {
                     rest += 8;
                     // Parse PID (supports decimal or hex with 0x)
                     char* end;

--- a/src/art.cc
+++ b/src/art.cc
@@ -167,7 +167,8 @@ void showFatalError(const char* message)
     exit(1);
 }
 
-static void addHeadPidMapping(int pid, const char* headName) {
+static void addHeadPidMapping(int pid, const char* headName)
+{
     if (gHeadPidMappingCount < MAX_HEAD_MAPPINGS) {
         gHeadPidMappings[gHeadPidMappingCount].pid = pid;
         strncpy(gHeadPidMappings[gHeadPidMappingCount].headName, headName, FILENAME_LENGTH - 1);
@@ -178,7 +179,8 @@ static void addHeadPidMapping(int pid, const char* headName) {
     }
 }
 
-const char* artGetHeadNameForPid(int pid) {
+const char* artGetHeadNameForPid(int pid)
+{
     for (int i = 0; i < gHeadPidMappingCount; i++) {
         if (gHeadPidMappings[i].pid == pid) {
             return gHeadPidMappings[i].headName;
@@ -1271,9 +1273,11 @@ static void artLoadModHeadData(ArtListDescription* desc)
 
             // Trim each part
             auto trim = [](char* s) -> char* {
-                while (*s && isspace(*s)) s++;
+                while (*s && isspace(*s))
+                    s++;
                 char* end = s + strlen(s) - 1;
-                while (end > s && isspace(*end)) end--;
+                while (end > s && isspace(*end))
+                    end--;
                 *(end + 1) = '\0';
                 return s;
             };
@@ -1311,12 +1315,15 @@ static void artLoadModHeadData(ArtListDescription* desc)
             // *** Parse optional npc_pid= tokens from the remainder of the line ***
             char* rest = badStr;
             // Move past the third number
-            while (*rest && !isspace(*rest)) rest++;
-            while (*rest && isspace(*rest)) rest++;
+            while (*rest && !isspace(*rest))
+                rest++;
+            while (*rest && isspace(*rest))
+                rest++;
 
             while (*rest) {
                 // Skip whitespace
-                while (*rest && isspace(*rest)) rest++;
+                while (*rest && isspace(*rest))
+                    rest++;
                 if (!*rest) break;
 
                 // Check for "npc_pid=" token (case-insensitive)
@@ -1334,7 +1341,8 @@ static void artLoadModHeadData(ArtListDescription* desc)
                     }
                 } else {
                     // Unknown token - skip to next space
-                    while (*rest && !isspace(*rest)) rest++;
+                    while (*rest && !isspace(*rest))
+                        rest++;
                 }
             }
         }

--- a/src/art.cc
+++ b/src/art.cc
@@ -28,6 +28,7 @@ const int MAX_ART_INDICES = 8192;
 // Maximum number of PID->head mappings
 #define MAX_HEAD_MAPPINGS 256
 #define MAX_BG_GVAR_MAPPINGS 256
+#define MAX_SCRIPT_MAPS 256
 
 typedef struct ArtListDescription {
     int flags;
@@ -68,6 +69,13 @@ static struct {
     int gvarIndex;
 } gHeadBgGvarMappings[MAX_BG_GVAR_MAPPINGS];
 static int gHeadBgGvarMappingCount = 0;
+
+static struct {
+    char script[64];
+    char head[64];
+    int bgGvar;   // -1 = none
+} scriptMaps[MAX_SCRIPT_MAPS];
+static int scriptMapCount = 0;
 
 static int artReadList(const char* path, char** out_arr, int* out_count);
 static int artCacheGetFileSizeImpl(int fid, int* out_size);
@@ -214,6 +222,41 @@ int getHeadBgGvarOverride(int pid)
             return gHeadBgGvarMappings[i].gvarIndex;
     }
     return -1;
+}
+
+static int findScriptMap(const char* script) {
+    for (int i = 0; i < scriptMapCount; i++)
+        if (compat_stricmp(scriptMaps[i].script, script) == 0)
+            return i;
+    return -1;
+}
+
+static void addScriptMap(const char* script, const char* head, int bgGvar) {
+    int idx = findScriptMap(script);
+    if (idx != -1) {
+        // Update existing entry (e.g., if same script appears again)
+        strncpy(scriptMaps[idx].head, head, sizeof(scriptMaps[0].head)-1);
+        scriptMaps[idx].bgGvar = bgGvar;
+        return;
+    }
+    if (scriptMapCount >= MAX_SCRIPT_MAPS) {
+        debugPrint("WARNING: Script mapping table full\n");
+        return;
+    }
+    strncpy(scriptMaps[scriptMapCount].script, script, sizeof(scriptMaps[0].script)-1);
+    strncpy(scriptMaps[scriptMapCount].head, head, sizeof(scriptMaps[0].head)-1);
+    scriptMaps[scriptMapCount].bgGvar = bgGvar;
+    scriptMapCount++;
+}
+
+const char* getHeadForScript(const char* script) {
+    int idx = findScriptMap(script);
+    return (idx != -1) ? scriptMaps[idx].head : nullptr;
+}
+
+int getBgGvarForScript(const char* script) {
+    int idx = findScriptMap(script);
+    return (idx != -1) ? scriptMaps[idx].bgGvar : -1;
 }
 
 // Helper to extract base filename without extension
@@ -1347,70 +1390,63 @@ static void artLoadModHeadData(ArtListDescription* desc)
             while (*rest && isspace(*rest))
                 rest++;
 
-            int current_pid = -1; // last seen PID, used for bg_gvar
+            int current_pid = -1;
+            char current_script[64] = {0};
+            bool have_script = false;
 
             while (*rest) {
-                // Skip whitespace
-                while (*rest && isspace(*rest))
-                    rest++;
+                while (*rest && isspace(*rest)) rest++;
                 if (!*rest) break;
 
-                // Look for '=' to separate key and value
                 char* eq = strchr(rest, '=');
-                if (!eq) {
-                    // No '=', skip to next space
-                    while (*rest && !isspace(*rest))
-                        rest++;
-                    continue;
-                }
+                if (!eq) { while (*rest && !isspace(*rest)) rest++; continue; }
 
-                // Extract key (before '=')
+                // Extract key
                 char* key_start = rest;
                 char* key_end = eq;
-                while (key_end > key_start && isspace(*(key_end - 1)))
-                    key_end--;
-                size_t key_len = key_end - key_start;
+                while (key_end > key_start && isspace(*(key_end-1))) key_end--;
+                size_t klen = key_end - key_start;
                 char key[64];
-                strncpy(key, key_start, key_len);
-                key[key_len] = '\0';
+                strncpy(key, key_start, klen);
+                key[klen] = '\0';
 
-                // Move rest past '='
+                // Move to value
                 rest = eq + 1;
-                // Skip whitespace before value
-                while (*rest && isspace(*rest))
-                    rest++;
-
-                // Extract value: stops at space or end of line
+                while (*rest && isspace(*rest)) rest++;
                 char* val_start = rest;
-                while (*rest && !isspace(*rest))
-                    rest++;
-                char* val_end = rest;
-                // Save the current position to continue scanning after value
-                char saved = *val_end;
-                *val_end = '\0';
+                while (*rest && !isspace(*rest)) rest++;
+                char saved = *rest;
+                *rest = '\0';
 
-                // Process key
                 if (strcmp(key, "npc_pid") == 0) {
-                    // Parse PID (hex or decimal)
-                    int pid = strtol(val_start, nullptr, 0);
-                    current_pid = pid;
-                    // Add mapping from PID to head (you already have addHeadPidMapping function)
-                    addHeadPidMapping(pid, filename);
-                    debugPrint("    Mapping NPC PID 0x%X -> head '%s'\n", pid, filename);
+                    current_pid = (int)strtol(val_start, nullptr, 0);
+                    have_script = false;
+                    addHeadPidMapping(current_pid, filename);
+                } else if (strcmp(key, "npc_script") == 0) {
+                    strncpy(current_script, val_start, sizeof(current_script)-1);
+                    current_script[sizeof(current_script)-1] = '\0';
+                    have_script = true;
+                    current_pid = -1;
+                    // Add script mapping (bgGvar will be updated later if present)
+                    addScriptMap(current_script, filename, -1);
                 } else if (strcmp(key, "bg_gvar") == 0) {
-                    if (current_pid != -1) {
-                        int gvarIndex = atoi(val_start);
-                        addHeadBgGvarMapping(current_pid, gvarIndex);
-                        debugPrint("    Mapping background GVAR %d to PID 0x%X\n", gvarIndex, current_pid);
-                    } else {
-                        debugPrint("    bg_gvar without preceding npc_pid, ignoring\n");
+                    int gvar = atoi(val_start);
+                    if (have_script) {
+                        // Update the most recent script mapping with bgGvar
+                        for (int i = 0; i < scriptMapCount; i++) {
+                            if (strcmp(scriptMaps[i].script, current_script) == 0) {
+                                scriptMaps[i].bgGvar = gvar;
+                                break;
+                            }
+                        }
+                    } else if (current_pid != -1) {
+                        addHeadBgGvarMapping(current_pid, gvar);
                     }
                 } else {
-                    debugPrint("    Unknown token: %s (ignored)\n", key);
+                    debugPrint("Unknown token: %s\n", key);
                 }
 
-                // Restore the character and continue
-                *val_end = saved;
+                *rest = saved;
             }
         }
         fileClose(stream);

--- a/src/art.cc
+++ b/src/art.cc
@@ -27,6 +27,7 @@ const int MAX_ART_INDICES = 8192;
 
 // Maximum number of PID->head mappings
 #define MAX_HEAD_MAPPINGS 256
+#define MAX_BG_GVAR_MAPPINGS 256
 
 typedef struct ArtListDescription {
     int flags;
@@ -61,6 +62,12 @@ static struct {
     char headName[FILENAME_LENGTH];
 } gHeadPidMappings[MAX_HEAD_MAPPINGS];
 static int gHeadPidMappingCount = 0;
+
+static struct {
+    int pid;
+    int gvarIndex;
+} gHeadBgGvarMappings[MAX_BG_GVAR_MAPPINGS];
+static int gHeadBgGvarMappingCount = 0;
 
 static int artReadList(const char* path, char** out_arr, int* out_count);
 static int artCacheGetFileSizeImpl(int fid, int* out_size);
@@ -187,6 +194,24 @@ const char* artGetHeadNameForPid(int pid)
         }
     }
     return nullptr;
+}
+
+static void addHeadBgGvarMapping(int pid, int gvarIndex) {
+    if (gHeadBgGvarMappingCount < MAX_BG_GVAR_MAPPINGS) {
+        gHeadBgGvarMappings[gHeadBgGvarMappingCount].pid = pid;
+        gHeadBgGvarMappings[gHeadBgGvarMappingCount].gvarIndex = gvarIndex;
+        gHeadBgGvarMappingCount++;
+    } else {
+        debugPrint("WARNING: Background GVAR mapping table full for PID %d\n", pid);
+    }
+}
+
+int getHeadBgGvarOverride(int pid) {
+    for (int i = 0; i < gHeadBgGvarMappingCount; i++) {
+        if (gHeadBgGvarMappings[i].pid == pid)
+            return gHeadBgGvarMappings[i].gvarIndex;
+    }
+    return -1;
 }
 
 // Helper to extract base filename without extension
@@ -1312,38 +1337,71 @@ static void artLoadModHeadData(ArtListDescription* desc)
             debugPrint("  Head %d (%s): good=%d, neutral=%d, bad=%d\n",
                 index, filename, good, neutral, bad);
 
-            // *** Parse optional npc_pid= tokens from the remainder of the line ***
+            // Parse optional npc_pid= and bg_gvar= tokens from the remainder of the line
             char* rest = badStr;
             // Move past the third number
-            while (*rest && !isspace(*rest))
-                rest++;
-            while (*rest && isspace(*rest))
-                rest++;
+            while (*rest && !isspace(*rest)) rest++;
+            while (*rest && isspace(*rest)) rest++;
+
+            int current_pid = -1;  // last seen PID, used for bg_gvar
 
             while (*rest) {
                 // Skip whitespace
-                while (*rest && isspace(*rest))
-                    rest++;
+                while (*rest && isspace(*rest)) rest++;
                 if (!*rest) break;
 
-                // Check for "npc_pid=" token (case-insensitive)
-                if (strncmp(rest, "npc_pid=", 8) == 0) {
-                    rest += 8;
-                    // Parse PID (supports decimal or hex with 0x)
-                    char* end;
-                    int pid = strtol(rest, &end, 0);
-                    if (end > rest) {
-                        addHeadPidMapping(pid, filename);
-                        debugPrint("    Mapping NPC PID 0x%X -> head '%s'\n", pid, filename);
-                        rest = end;
+                // Look for '=' to separate key and value
+                char* eq = strchr(rest, '=');
+                if (!eq) {
+                    // No '=', skip to next space
+                    while (*rest && !isspace(*rest)) rest++;
+                    continue;
+                }
+
+                // Extract key (before '=')
+                char* key_start = rest;
+                char* key_end = eq;
+                while (key_end > key_start && isspace(*(key_end-1))) key_end--;
+                size_t key_len = key_end - key_start;
+                char key[64];
+                strncpy(key, key_start, key_len);
+                key[key_len] = '\0';
+
+                // Move rest past '='
+                rest = eq + 1;
+                // Skip whitespace before value
+                while (*rest && isspace(*rest)) rest++;
+
+                // Extract value: stops at space or end of line
+                char* val_start = rest;
+                while (*rest && !isspace(*rest)) rest++;
+                char* val_end = rest;
+                // Save the current position to continue scanning after value
+                char saved = *val_end;
+                *val_end = '\0';
+
+                // Process key
+                if (strcmp(key, "npc_pid") == 0) {
+                    // Parse PID (hex or decimal)
+                    int pid = strtol(val_start, nullptr, 0);
+                    current_pid = pid;
+                    // Add mapping from PID to head (you already have addHeadPidMapping function)
+                    addHeadPidMapping(pid, filename);
+                    debugPrint("    Mapping NPC PID 0x%X -> head '%s'\n", pid, filename);
+                } else if (strcmp(key, "bg_gvar") == 0) {
+                    if (current_pid != -1) {
+                        int gvarIndex = atoi(val_start);
+                        addHeadBgGvarMapping(current_pid, gvarIndex);
+                        debugPrint("    Mapping background GVAR %d to PID 0x%X\n", gvarIndex, current_pid);
                     } else {
-                        debugPrint("    Invalid npc_pid= value: %s\n", rest);
+                        debugPrint("    bg_gvar without preceding npc_pid, ignoring\n");
                     }
                 } else {
-                    // Unknown token - skip to next space
-                    while (*rest && !isspace(*rest))
-                        rest++;
+                    debugPrint("    Unknown token: %s (ignored)\n", key);
                 }
+
+                // Restore the character and continue
+                *val_end = saved;
             }
         }
         fileClose(stream);

--- a/src/art.cc
+++ b/src/art.cc
@@ -25,6 +25,9 @@ namespace fallout {
 
 const int MAX_ART_INDICES = 8192;
 
+// Maximum number of PID->head mappings
+#define MAX_HEAD_MAPPINGS 256
+
 typedef struct ArtListDescription {
     int flags;
     char name[16];
@@ -52,6 +55,12 @@ typedef struct HeadDescription {
     int neutralFidgetCount;
     int badFidgetCount;
 } HeadDescription;
+
+static struct {
+    int pid;
+    char headName[FILENAME_LENGTH];
+} gHeadPidMappings[MAX_HEAD_MAPPINGS];
+static int gHeadPidMappingCount = 0;
 
 static int artReadList(const char* path, char** out_arr, int* out_count);
 static int artCacheGetFileSizeImpl(int fid, int* out_size);
@@ -156,6 +165,26 @@ void showFatalError(const char* message)
     debugPrint("FATAL ART ERROR: %s", message);
     showMesageBox(message); // Corrected spelling
     exit(1);
+}
+
+static void addHeadPidMapping(int pid, const char* headName) {
+    if (gHeadPidMappingCount < MAX_HEAD_MAPPINGS) {
+        gHeadPidMappings[gHeadPidMappingCount].pid = pid;
+        strncpy(gHeadPidMappings[gHeadPidMappingCount].headName, headName, FILENAME_LENGTH - 1);
+        gHeadPidMappings[gHeadPidMappingCount].headName[FILENAME_LENGTH - 1] = '\0';
+        gHeadPidMappingCount++;
+    } else {
+        debugPrint("WARNING: head PID mapping table full, ignoring mapping for PID %d\n", pid);
+    }
+}
+
+const char* artGetHeadNameForPid(int pid) {
+    for (int i = 0; i < gHeadPidMappingCount; i++) {
+        if (gHeadPidMappings[i].pid == pid) {
+            return gHeadPidMappings[i].headName;
+        }
+    }
+    return nullptr;
 }
 
 // Helper to extract base filename without extension
@@ -1214,7 +1243,7 @@ static void artLoadModHeadData(ArtListDescription* desc)
             if (*p == '\0' || *p == '#')
                 continue; // skip empty lines and comments
 
-            // Format: filename,good,neutral,bad
+            // Format: filename,good,neutral,bad override [casdy,3,3,3 npc_pid=0x1000059 ...]
             char* filename = p;
             char* comma1 = strchr(p, ',');
             if (!comma1) {
@@ -1242,11 +1271,9 @@ static void artLoadModHeadData(ArtListDescription* desc)
 
             // Trim each part
             auto trim = [](char* s) -> char* {
-                while (*s && isspace((unsigned char)*s))
-                    s++;
+                while (*s && isspace(*s)) s++;
                 char* end = s + strlen(s) - 1;
-                while (end > s && isspace((unsigned char)*end))
-                    end--;
+                while (end > s && isspace(*end)) end--;
                 *(end + 1) = '\0';
                 return s;
             };
@@ -1269,17 +1296,48 @@ static void artLoadModHeadData(ArtListDescription* desc)
                 }
             }
 
-            if (index != -1) {
-                gHeadDescriptions[index].goodFidgetCount = good;
-                gHeadDescriptions[index].neutralFidgetCount = neutral;
-                gHeadDescriptions[index].badFidgetCount = bad;
-                debugPrint("  Head %d (%s): good=%d, neutral=%d, bad=%d\n",
-                    index, filename, good, neutral, bad);
-            } else {
+            if (index == -1) {
                 debugPrint("  Warning: Could not find head filename '%s' from mod list\n", filename);
+                continue;
+            }
+
+            // Store fidget counts
+            gHeadDescriptions[index].goodFidgetCount = good;
+            gHeadDescriptions[index].neutralFidgetCount = neutral;
+            gHeadDescriptions[index].badFidgetCount = bad;
+            debugPrint("  Head %d (%s): good=%d, neutral=%d, bad=%d\n",
+                index, filename, good, neutral, bad);
+
+            // *** Parse optional npc_pid= tokens from the remainder of the line ***
+            char* rest = badStr;
+            // Move past the third number
+            while (*rest && !isspace(*rest)) rest++;
+            while (*rest && isspace(*rest)) rest++;
+
+            while (*rest) {
+                // Skip whitespace
+                while (*rest && isspace(*rest)) rest++;
+                if (!*rest) break;
+
+                // Check for "npc_pid=" token (case-insensitive)
+                if (strncasecmp(rest, "npc_pid=", 8) == 0) {
+                    rest += 8;
+                    // Parse PID (supports decimal or hex with 0x)
+                    char* end;
+                    int pid = strtol(rest, &end, 0);
+                    if (end > rest) {
+                        addHeadPidMapping(pid, filename);
+                        debugPrint("    Mapping NPC PID 0x%X -> head '%s'\n", pid, filename);
+                        rest = end;
+                    } else {
+                        debugPrint("    Invalid npc_pid= value: %s\n", rest);
+                    }
+                } else {
+                    // Unknown token - skip to next space
+                    while (*rest && !isspace(*rest)) rest++;
+                }
             }
         }
-
         fileClose(stream);
     }
 

--- a/src/art.cc
+++ b/src/art.cc
@@ -59,21 +59,10 @@ typedef struct HeadDescription {
 } HeadDescription;
 
 static struct {
-    int pid;
-    char headName[FILENAME_LENGTH];
-} gHeadPidMappings[MAX_HEAD_MAPPINGS];
-static int gHeadPidMappingCount = 0;
-
-static struct {
-    int pid;
-    int gvarIndex;
-} gHeadBgGvarMappings[MAX_BG_GVAR_MAPPINGS];
-static int gHeadBgGvarMappingCount = 0;
-
-static struct {
     char script[64];
     char head[64];
-    int bgGvar; // -1 = none
+    int bgGvar;      // -1 = none (dynamic from global var)
+    int staticBg;    // -1 = none (static background index)
 } scriptMaps[MAX_SCRIPT_MAPS];
 static int scriptMapCount = 0;
 
@@ -182,48 +171,6 @@ void showFatalError(const char* message)
     exit(1);
 }
 
-static void addHeadPidMapping(int pid, const char* headName)
-{
-    if (gHeadPidMappingCount < MAX_HEAD_MAPPINGS) {
-        gHeadPidMappings[gHeadPidMappingCount].pid = pid;
-        strncpy(gHeadPidMappings[gHeadPidMappingCount].headName, headName, FILENAME_LENGTH - 1);
-        gHeadPidMappings[gHeadPidMappingCount].headName[FILENAME_LENGTH - 1] = '\0';
-        gHeadPidMappingCount++;
-    } else {
-        debugPrint("WARNING: head PID mapping table full, ignoring mapping for PID %d\n", pid);
-    }
-}
-
-const char* artGetHeadNameForPid(int pid)
-{
-    for (int i = 0; i < gHeadPidMappingCount; i++) {
-        if (gHeadPidMappings[i].pid == pid) {
-            return gHeadPidMappings[i].headName;
-        }
-    }
-    return nullptr;
-}
-
-static void addHeadBgGvarMapping(int pid, int gvarIndex)
-{
-    if (gHeadBgGvarMappingCount < MAX_BG_GVAR_MAPPINGS) {
-        gHeadBgGvarMappings[gHeadBgGvarMappingCount].pid = pid;
-        gHeadBgGvarMappings[gHeadBgGvarMappingCount].gvarIndex = gvarIndex;
-        gHeadBgGvarMappingCount++;
-    } else {
-        debugPrint("WARNING: Background GVAR mapping table full for PID %d\n", pid);
-    }
-}
-
-int getHeadBgGvarOverride(int pid)
-{
-    for (int i = 0; i < gHeadBgGvarMappingCount; i++) {
-        if (gHeadBgGvarMappings[i].pid == pid)
-            return gHeadBgGvarMappings[i].gvarIndex;
-    }
-    return -1;
-}
-
 static int findScriptMap(const char* script)
 {
     for (int i = 0; i < scriptMapCount; i++)
@@ -232,22 +179,19 @@ static int findScriptMap(const char* script)
     return -1;
 }
 
-static void addScriptMap(const char* script, const char* head, int bgGvar)
-{
+static void addScriptMap(const char* script, const char* head, int bgGvar, int staticBg) {
     int idx = findScriptMap(script);
     if (idx != -1) {
-        // Update existing entry (e.g., if same script appears again)
-        strncpy(scriptMaps[idx].head, head, sizeof(scriptMaps[0].head) - 1);
+        strncpy(scriptMaps[idx].head, head, sizeof(scriptMaps[0].head)-1);
         scriptMaps[idx].bgGvar = bgGvar;
+        scriptMaps[idx].staticBg = staticBg;
         return;
     }
-    if (scriptMapCount >= MAX_SCRIPT_MAPS) {
-        debugPrint("WARNING: Script mapping table full\n");
-        return;
-    }
-    strncpy(scriptMaps[scriptMapCount].script, script, sizeof(scriptMaps[0].script) - 1);
-    strncpy(scriptMaps[scriptMapCount].head, head, sizeof(scriptMaps[0].head) - 1);
+    if (scriptMapCount >= MAX_SCRIPT_MAPS) return;
+    strncpy(scriptMaps[scriptMapCount].script, script, sizeof(scriptMaps[0].script)-1);
+    strncpy(scriptMaps[scriptMapCount].head, head, sizeof(scriptMaps[0].head)-1);
     scriptMaps[scriptMapCount].bgGvar = bgGvar;
+    scriptMaps[scriptMapCount].staticBg = staticBg;
     scriptMapCount++;
 }
 
@@ -261,6 +205,11 @@ int getBgGvarForScript(const char* script)
 {
     int idx = findScriptMap(script);
     return (idx != -1) ? scriptMaps[idx].bgGvar : -1;
+}
+
+int getStaticBgForScript(const char* script) {
+    int idx = findScriptMap(script);
+    return (idx != -1) ? scriptMaps[idx].staticBg : -1;
 }
 
 // Helper to extract base filename without extension
@@ -1386,35 +1335,31 @@ static void artLoadModHeadData(ArtListDescription* desc)
             debugPrint("  Head %d (%s): good=%d, neutral=%d, bad=%d\n",
                 index, filename, good, neutral, bad);
 
-            // Parse optional npc_pid= and bg_gvar= tokens from the remainder of the line
+            // Parse optional npc_script, bg_gvar, background tokens
             char* rest = badStr;
             // Move past the third number
-            while (*rest && !isspace(*rest))
-                rest++;
-            while (*rest && isspace(*rest))
-                rest++;
+            while (*rest && !isspace(*rest)) rest++;
+            while (*rest && isspace(*rest)) rest++;
 
-            int current_pid = -1;
-            char current_script[64] = { 0 };
+            char current_script[64] = {0};
             bool have_script = false;
 
             while (*rest) {
-                while (*rest && isspace(*rest))
-                    rest++;
+                // Skip whitespace
+                while (*rest && isspace(*rest)) rest++;
                 if (!*rest) break;
 
                 char* eq = strchr(rest, '=');
                 if (!eq) {
-                    while (*rest && !isspace(*rest))
-                        rest++;
+                    // No '=', skip to next space
+                    while (*rest && !isspace(*rest)) rest++;
                     continue;
                 }
 
                 // Extract key
                 char* key_start = rest;
                 char* key_end = eq;
-                while (key_end > key_start && isspace(*(key_end - 1)))
-                    key_end--;
+                while (key_end > key_start && isspace(*(key_end-1))) key_end--;
                 size_t klen = key_end - key_start;
                 char key[64];
                 strncpy(key, key_start, klen);
@@ -1422,37 +1367,39 @@ static void artLoadModHeadData(ArtListDescription* desc)
 
                 // Move to value
                 rest = eq + 1;
-                while (*rest && isspace(*rest))
-                    rest++;
+                while (*rest && isspace(*rest)) rest++;
                 char* val_start = rest;
-                while (*rest && !isspace(*rest))
-                    rest++;
+                while (*rest && !isspace(*rest)) rest++;
                 char saved = *rest;
                 *rest = '\0';
 
-                if (strcmp(key, "npc_pid") == 0) {
-                    current_pid = (int)strtol(val_start, nullptr, 0);
-                    have_script = false;
-                    addHeadPidMapping(current_pid, filename);
-                } else if (strcmp(key, "npc_script") == 0) {
-                    strncpy(current_script, val_start, sizeof(current_script) - 1);
-                    current_script[sizeof(current_script) - 1] = '\0';
+                if (strcmp(key, "npc_script") == 0) {
+                    strncpy(current_script, val_start, sizeof(current_script)-1);
+                    current_script[sizeof(current_script)-1] = '\0';
                     have_script = true;
-                    current_pid = -1;
-                    // Add script mapping (bgGvar will be updated later if present)
-                    addScriptMap(current_script, filename, -1);
+                    // Add mapping with default -1 for bgGvar and staticBg
+                    addScriptMap(current_script, filename, -1, -1);
                 } else if (strcmp(key, "bg_gvar") == 0) {
-                    int gvar = atoi(val_start);
                     if (have_script) {
-                        // Update the most recent script mapping with bgGvar
+                        int gvar = atoi(val_start);
+                        // Update the current script's bgGvar
                         for (int i = 0; i < scriptMapCount; i++) {
                             if (strcmp(scriptMaps[i].script, current_script) == 0) {
                                 scriptMaps[i].bgGvar = gvar;
                                 break;
                             }
                         }
-                    } else if (current_pid != -1) {
-                        addHeadBgGvarMapping(current_pid, gvar);
+                    }
+                } else if (strcmp(key, "background") == 0) {
+                    if (have_script) {
+                        int bg = atoi(val_start);
+                        // Update the current script's staticBg
+                        for (int i = 0; i < scriptMapCount; i++) {
+                            if (strcmp(scriptMaps[i].script, current_script) == 0) {
+                                scriptMaps[i].staticBg = bg;
+                                break;
+                            }
+                        }
                     }
                 } else {
                     debugPrint("Unknown token: %s\n", key);

--- a/src/art.cc
+++ b/src/art.cc
@@ -61,8 +61,8 @@ typedef struct HeadDescription {
 static struct {
     char script[64];
     char head[64];
-    int bgGvar;      // -1 = none (dynamic from global var)
-    int staticBg;    // -1 = none (static background index)
+    int bgGvar; // -1 = none (dynamic from global var)
+    int staticBg; // -1 = none (static background index)
 } scriptMaps[MAX_SCRIPT_MAPS];
 static int scriptMapCount = 0;
 
@@ -179,17 +179,18 @@ static int findScriptMap(const char* script)
     return -1;
 }
 
-static void addScriptMap(const char* script, const char* head, int bgGvar, int staticBg) {
+static void addScriptMap(const char* script, const char* head, int bgGvar, int staticBg)
+{
     int idx = findScriptMap(script);
     if (idx != -1) {
-        strncpy(scriptMaps[idx].head, head, sizeof(scriptMaps[0].head)-1);
+        strncpy(scriptMaps[idx].head, head, sizeof(scriptMaps[0].head) - 1);
         scriptMaps[idx].bgGvar = bgGvar;
         scriptMaps[idx].staticBg = staticBg;
         return;
     }
     if (scriptMapCount >= MAX_SCRIPT_MAPS) return;
-    strncpy(scriptMaps[scriptMapCount].script, script, sizeof(scriptMaps[0].script)-1);
-    strncpy(scriptMaps[scriptMapCount].head, head, sizeof(scriptMaps[0].head)-1);
+    strncpy(scriptMaps[scriptMapCount].script, script, sizeof(scriptMaps[0].script) - 1);
+    strncpy(scriptMaps[scriptMapCount].head, head, sizeof(scriptMaps[0].head) - 1);
     scriptMaps[scriptMapCount].bgGvar = bgGvar;
     scriptMaps[scriptMapCount].staticBg = staticBg;
     scriptMapCount++;
@@ -207,7 +208,8 @@ int getBgGvarForScript(const char* script)
     return (idx != -1) ? scriptMaps[idx].bgGvar : -1;
 }
 
-int getStaticBgForScript(const char* script) {
+int getStaticBgForScript(const char* script)
+{
     int idx = findScriptMap(script);
     return (idx != -1) ? scriptMaps[idx].staticBg : -1;
 }
@@ -1338,28 +1340,33 @@ static void artLoadModHeadData(ArtListDescription* desc)
             // Parse optional npc_script, bg_gvar, background tokens
             char* rest = badStr;
             // Move past the third number
-            while (*rest && !isspace(*rest)) rest++;
-            while (*rest && isspace(*rest)) rest++;
+            while (*rest && !isspace(*rest))
+                rest++;
+            while (*rest && isspace(*rest))
+                rest++;
 
-            char current_script[64] = {0};
+            char current_script[64] = { 0 };
             bool have_script = false;
 
             while (*rest) {
                 // Skip whitespace
-                while (*rest && isspace(*rest)) rest++;
+                while (*rest && isspace(*rest))
+                    rest++;
                 if (!*rest) break;
 
                 char* eq = strchr(rest, '=');
                 if (!eq) {
                     // No '=', skip to next space
-                    while (*rest && !isspace(*rest)) rest++;
+                    while (*rest && !isspace(*rest))
+                        rest++;
                     continue;
                 }
 
                 // Extract key
                 char* key_start = rest;
                 char* key_end = eq;
-                while (key_end > key_start && isspace(*(key_end-1))) key_end--;
+                while (key_end > key_start && isspace(*(key_end - 1)))
+                    key_end--;
                 size_t klen = key_end - key_start;
                 char key[64];
                 strncpy(key, key_start, klen);
@@ -1367,15 +1374,17 @@ static void artLoadModHeadData(ArtListDescription* desc)
 
                 // Move to value
                 rest = eq + 1;
-                while (*rest && isspace(*rest)) rest++;
+                while (*rest && isspace(*rest))
+                    rest++;
                 char* val_start = rest;
-                while (*rest && !isspace(*rest)) rest++;
+                while (*rest && !isspace(*rest))
+                    rest++;
                 char saved = *rest;
                 *rest = '\0';
 
                 if (strcmp(key, "npc_script") == 0) {
-                    strncpy(current_script, val_start, sizeof(current_script)-1);
-                    current_script[sizeof(current_script)-1] = '\0';
+                    strncpy(current_script, val_start, sizeof(current_script) - 1);
+                    current_script[sizeof(current_script) - 1] = '\0';
                     have_script = true;
                     // Add mapping with default -1 for bgGvar and staticBg
                     addScriptMap(current_script, filename, -1, -1);

--- a/src/art.cc
+++ b/src/art.cc
@@ -196,7 +196,8 @@ const char* artGetHeadNameForPid(int pid)
     return nullptr;
 }
 
-static void addHeadBgGvarMapping(int pid, int gvarIndex) {
+static void addHeadBgGvarMapping(int pid, int gvarIndex)
+{
     if (gHeadBgGvarMappingCount < MAX_BG_GVAR_MAPPINGS) {
         gHeadBgGvarMappings[gHeadBgGvarMappingCount].pid = pid;
         gHeadBgGvarMappings[gHeadBgGvarMappingCount].gvarIndex = gvarIndex;
@@ -206,7 +207,8 @@ static void addHeadBgGvarMapping(int pid, int gvarIndex) {
     }
 }
 
-int getHeadBgGvarOverride(int pid) {
+int getHeadBgGvarOverride(int pid)
+{
     for (int i = 0; i < gHeadBgGvarMappingCount; i++) {
         if (gHeadBgGvarMappings[i].pid == pid)
             return gHeadBgGvarMappings[i].gvarIndex;
@@ -1340,28 +1342,33 @@ static void artLoadModHeadData(ArtListDescription* desc)
             // Parse optional npc_pid= and bg_gvar= tokens from the remainder of the line
             char* rest = badStr;
             // Move past the third number
-            while (*rest && !isspace(*rest)) rest++;
-            while (*rest && isspace(*rest)) rest++;
+            while (*rest && !isspace(*rest))
+                rest++;
+            while (*rest && isspace(*rest))
+                rest++;
 
-            int current_pid = -1;  // last seen PID, used for bg_gvar
+            int current_pid = -1; // last seen PID, used for bg_gvar
 
             while (*rest) {
                 // Skip whitespace
-                while (*rest && isspace(*rest)) rest++;
+                while (*rest && isspace(*rest))
+                    rest++;
                 if (!*rest) break;
 
                 // Look for '=' to separate key and value
                 char* eq = strchr(rest, '=');
                 if (!eq) {
                     // No '=', skip to next space
-                    while (*rest && !isspace(*rest)) rest++;
+                    while (*rest && !isspace(*rest))
+                        rest++;
                     continue;
                 }
 
                 // Extract key (before '=')
                 char* key_start = rest;
                 char* key_end = eq;
-                while (key_end > key_start && isspace(*(key_end-1))) key_end--;
+                while (key_end > key_start && isspace(*(key_end - 1)))
+                    key_end--;
                 size_t key_len = key_end - key_start;
                 char key[64];
                 strncpy(key, key_start, key_len);
@@ -1370,11 +1377,13 @@ static void artLoadModHeadData(ArtListDescription* desc)
                 // Move rest past '='
                 rest = eq + 1;
                 // Skip whitespace before value
-                while (*rest && isspace(*rest)) rest++;
+                while (*rest && isspace(*rest))
+                    rest++;
 
                 // Extract value: stops at space or end of line
                 char* val_start = rest;
-                while (*rest && !isspace(*rest)) rest++;
+                while (*rest && !isspace(*rest))
+                    rest++;
                 char* val_end = rest;
                 // Save the current position to continue scanning after value
                 char saved = *val_end;

--- a/src/art.h
+++ b/src/art.h
@@ -156,6 +156,8 @@ Art* artLoad(const char* path);
 int artRead(const char* path, unsigned char* data);
 int artWrite(const char* path, unsigned char* data);
 
+const char* artGetHeadNameForPid(int pid);
+
 class FrmImage {
 public:
     FrmImage();

--- a/src/art.h
+++ b/src/art.h
@@ -156,10 +156,9 @@ Art* artLoad(const char* path);
 int artRead(const char* path, unsigned char* data);
 int artWrite(const char* path, unsigned char* data);
 
-const char* artGetHeadNameForPid(int pid);
-int getHeadBgGvarOverride(int pid);
 const char* getHeadForScript(const char* script);
 int getBgGvarForScript(const char* script);
+int getStaticBgForScript(const char* script);
 
 class FrmImage {
 public:

--- a/src/art.h
+++ b/src/art.h
@@ -158,6 +158,8 @@ int artWrite(const char* path, unsigned char* data);
 
 const char* artGetHeadNameForPid(int pid);
 int getHeadBgGvarOverride(int pid);
+const char* getHeadForScript(const char* script);
+int getBgGvarForScript(const char* script);
 
 class FrmImage {
 public:

--- a/src/art.h
+++ b/src/art.h
@@ -157,6 +157,7 @@ int artRead(const char* path, unsigned char* data);
 int artWrite(const char* path, unsigned char* data);
 
 const char* artGetHeadNameForPid(int pid);
+int getHeadBgGvarOverride(int pid);
 
 class FrmImage {
 public:

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -2620,7 +2620,6 @@ void _gdSetupFidget(int headFid, int reaction)
 {
 
     gGameDialogFidgetFrmCurrentFrame = 0;
-
     if (headFid == -1) {
         gGameDialogFidgetFid = -1;
         gGameDialogFidgetFrm = nullptr;
@@ -2634,6 +2633,15 @@ void _gdSetupFidget(int headFid, int reaction)
         _lipsFp = nullptr;
         return;
     }
+
+    // Map Sonora reaction constants (49,50,51) to fidget groups (1,4,7) ---
+    int fidgetGroup = reaction;
+    if (reaction == 49)      // HEAD_REACTION_GOOD
+        fidgetGroup = FIDGET_GOOD;           // 1
+    else if (reaction == 50) // HEAD_REACTION_NEUTRAL
+        fidgetGroup = FIDGET_NEUTRAL;        // 4
+    else if (reaction == 51)  // HEAD_REACTION_BAD
+        fidgetGroup = FIDGET_BAD;            // 7
 
     // Extract the actual head index from the FID (supports modded heads)
     int headFrmId = artGetIndex(headFid);
@@ -2672,7 +2680,7 @@ void _gdSetupFidget(int headFid, int reaction)
         }
     }
 
-    int fid = buildFid(OBJ_TYPE_HEAD, headFrmId, reaction, 0, 0);
+    int fid = buildFid(OBJ_TYPE_HEAD, headFrmId, fidgetGroup, 0, 0);
     int fidgetCount = artGetFidgetCount(fid);
     if (fidgetCount == -1) {
         debugPrint("\tError - No available fidgets for given frame id\n");
@@ -2713,9 +2721,10 @@ void _gdSetupFidget(int headFid, int reaction)
         }
     }
 
-    gGameDialogFidgetFid = buildFid(OBJ_TYPE_HEAD, headFrmId, reaction, fidget, 0);
+    gGameDialogFidgetFid = buildFid(OBJ_TYPE_HEAD, headFrmId, fidgetGroup, fidget, 0);
     gGameDialogFidgetFrmCurrentFrame = 0;
     gGameDialogFidgetFrm = artLock(gGameDialogFidgetFid, &gGameDialogFidgetFrmHandle);
+
     if (gGameDialogFidgetFrm == nullptr) {
         debugPrint("failure!\n");
 
@@ -2725,7 +2734,7 @@ void _gdSetupFidget(int headFid, int reaction)
     }
 
     gGameDialogFidgetLastUpdateTimestamp = 0;
-    gGameDialogFidgetReaction = reaction;
+    gGameDialogFidgetReaction = fidgetGroup;
     gGameDialogFidgetUpdateDelay = 1000 / artGetFramesPerSecond(gGameDialogFidgetFrm);
 }
 

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -956,7 +956,7 @@ int _gdialogInitFromScript(int headFid, int reaction)
     int bgGvarIndex = getHeadBgGvarOverride(gGameDialogSpeaker->pid);
     if (bgGvarIndex != -1) {
         int bgValue = gameGetGlobalVar(bgGvarIndex);
-        if (bgValue != -1) {          // -1 means "no override"
+        if (bgValue != -1) { // -1 means "no override"
             gameDialogSetBackground(bgValue);
         }
     }

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -2636,12 +2636,12 @@ void _gdSetupFidget(int headFid, int reaction)
 
     // Map Sonora reaction constants (49,50,51) to fidget groups (1,4,7) ---
     int fidgetGroup = reaction;
-    if (reaction == 49)      // HEAD_REACTION_GOOD
-        fidgetGroup = FIDGET_GOOD;           // 1
+    if (reaction == 49) // HEAD_REACTION_GOOD
+        fidgetGroup = FIDGET_GOOD; // 1
     else if (reaction == 50) // HEAD_REACTION_NEUTRAL
-        fidgetGroup = FIDGET_NEUTRAL;        // 4
-    else if (reaction == 51)  // HEAD_REACTION_BAD
-        fidgetGroup = FIDGET_BAD;            // 7
+        fidgetGroup = FIDGET_NEUTRAL; // 4
+    else if (reaction == 51) // HEAD_REACTION_BAD
+        fidgetGroup = FIDGET_BAD; // 7
 
     // Extract the actual head index from the FID (supports modded heads)
     int headFrmId = artGetIndex(headFid);

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -926,40 +926,61 @@ int _gdialogInitFromScript(int headFid, int reaction)
         return 0;
     }
 
-    // Check for PID->head override (loaded from heads_*.lst files)
-    if (headFid == -1) {
-        const char* headName = artGetHeadNameForPid(gGameDialogSpeaker->pid);
+    // ====== HEAD OVERRIDE (script first, then PID) ======
+    bool scriptOverrideUsed = false;
+    char scriptBase[64];
+
+    if (gGameDialogSpeaker->sid != -1 && scriptGetBaseName(gGameDialogSpeaker->sid, scriptBase, sizeof(scriptBase))) {
+        const char* headName = getHeadForScript(scriptBase);
         if (headName != nullptr) {
-            // Find the art index for this head filename
             int headIndex = artFindVariant(OBJ_TYPE_HEAD, -1, headName);
             if (headIndex != -1) {
-                // Build a valid head FID (neutral animation, rotation 0)
                 headFid = buildFid(OBJ_TYPE_HEAD, headIndex, 0, 0, 0);
-                // Override found – treat as if a head was provided
                 gGameDialogOldMusicVolume = -1;
                 backgroundSoundDelete();
+                gGameDialogHeadFid = headFid;
+                scriptOverrideUsed = true;
+            }
+        }
+    }
+
+    if (!scriptOverrideUsed && headFid == -1) {
+        const char* headName = artGetHeadNameForPid(gGameDialogSpeaker->pid);
+        if (headName != nullptr) {
+            int headIndex = artFindVariant(OBJ_TYPE_HEAD, -1, headName);
+            if (headIndex != -1) {
+                headFid = buildFid(OBJ_TYPE_HEAD, headIndex, 0, 0, 0);
+                gGameDialogOldMusicVolume = -1;
+                backgroundSoundDelete();
+                gGameDialogHeadFid = headFid;
             } else {
-                debugPrint("Warning: Head '%s' not found for PID 0x%X\n", headName, gGameDialogSpeaker->pid);
-                // Fallback to original music volume adjustment
                 gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
             }
         } else {
-            // SFALL: Fix the music volume when entering the dialog.
             gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
         }
-    } else {
+    } else if (!scriptOverrideUsed && headFid != -1) {
         gGameDialogOldMusicVolume = -1;
         backgroundSoundDelete();
     }
 
-    // If this NPC has a background GVAR override, read it and apply
-    int bgGvarIndex = getHeadBgGvarOverride(gGameDialogSpeaker->pid);
-    if (bgGvarIndex != -1) {
-        int bgValue = gameGetGlobalVar(bgGvarIndex);
-        if (bgValue != -1) { // -1 means "no override"
-            gameDialogSetBackground(bgValue);
+    // Apply background GVAR override (script first, then PID)
+    if (headFid != -1) {
+        int bgGvar = -1;
+        if (gGameDialogSpeaker->sid != -1 && scriptGetBaseName(gGameDialogSpeaker->sid, scriptBase, sizeof(scriptBase))) {
+            bgGvar = getBgGvarForScript(scriptBase);
+        }
+        if (bgGvar == -1) {
+            bgGvar = getHeadBgGvarOverride(gGameDialogSpeaker->pid);
+        }
+        if (bgGvar != -1) {
+            int bgVal = gameGetGlobalVar(bgGvar);
+            if (bgVal != -1) {
+                gameDialogSetBackground(bgVal);
+            }
         }
     }
+    // ====== END OVERRIDE ======
 
     animationStop();
 

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -944,8 +944,8 @@ int _gdialogInitFromScript(int headFid, int reaction)
                 gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
             }
         } else {
-                // SFALL: Fix the music volume when entering the dialog.
-                gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
+            // SFALL: Fix the music volume when entering the dialog.
+            gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
         }
     } else {
         gGameDialogOldMusicVolume = -1;

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -926,6 +926,32 @@ int _gdialogInitFromScript(int headFid, int reaction)
         return 0;
     }
 
+    // Check for PID->head override (loaded from heads_*.lst files)
+    if (headFid == -1) {
+        const char* headName = artGetHeadNameForPid(gGameDialogSpeaker->pid);
+        if (headName != nullptr) {
+            // Find the art index for this head filename
+            int headIndex = artFindVariant(OBJ_TYPE_HEAD, -1, headName);
+            if (headIndex != -1) {
+                // Build a valid head FID (neutral animation, rotation 0)
+                headFid = buildFid(OBJ_TYPE_HEAD, headIndex, 0, 0, 0);
+                // Override found – treat as if a head was provided
+                gGameDialogOldMusicVolume = -1;
+                backgroundSoundDelete();
+            } else {
+                debugPrint("Warning: Head '%s' not found for PID 0x%X\n", headName, gGameDialogSpeaker->pid);
+                // Fallback to original music volume adjustment
+                gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
+            }
+        } else {
+                // SFALL: Fix the music volume when entering the dialog.
+                gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
+        }
+    } else {
+        gGameDialogOldMusicVolume = -1;
+        backgroundSoundDelete();
+    }
+
     animationStop();
 
     _boxesWereDisabled = indicatorBarHide();
@@ -962,14 +988,6 @@ int _gdialogInitFromScript(int headFid, int reaction)
     _gdSetupFidget(headFid, reaction);
     _gdialog_state = GAME_DIALOG_ACTIVE;
     _gmouse_disable_scrolling();
-
-    if (headFid == -1) {
-        // SFALL: Fix the music volume when entering the dialog.
-        gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
-    } else {
-        gGameDialogOldMusicVolume = -1;
-        backgroundSoundDelete();
-    }
 
     _gdDialogWentOff = true;
 

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -926,7 +926,7 @@ int _gdialogInitFromScript(int headFid, int reaction)
         return 0;
     }
 
-    // ====== HEAD OVERRIDE (script first, then PID) ======
+    // ====== HEAD OVERRIDE  ======
     bool scriptOverrideUsed = false;
     char scriptBase[64];
 
@@ -944,40 +944,20 @@ int _gdialogInitFromScript(int headFid, int reaction)
         }
     }
 
-    if (!scriptOverrideUsed && headFid == -1) {
-        const char* headName = artGetHeadNameForPid(gGameDialogSpeaker->pid);
-        if (headName != nullptr) {
-            int headIndex = artFindVariant(OBJ_TYPE_HEAD, -1, headName);
-            if (headIndex != -1) {
-                headFid = buildFid(OBJ_TYPE_HEAD, headIndex, 0, 0, 0);
-                gGameDialogOldMusicVolume = -1;
-                backgroundSoundDelete();
-                gGameDialogHeadFid = headFid;
-            } else {
-                gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
-            }
-        } else {
-            gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
-        }
-    } else if (!scriptOverrideUsed && headFid != -1) {
-        gGameDialogOldMusicVolume = -1;
-        backgroundSoundDelete();
-    }
-
-    // Apply background GVAR override (script first, then PID)
     if (headFid != -1) {
-        int bgGvar = -1;
+        int bg = -1;
+        char scriptBase[64];
         if (gGameDialogSpeaker->sid != -1 && scriptGetBaseName(gGameDialogSpeaker->sid, scriptBase, sizeof(scriptBase))) {
-            bgGvar = getBgGvarForScript(scriptBase);
-        }
-        if (bgGvar == -1) {
-            bgGvar = getHeadBgGvarOverride(gGameDialogSpeaker->pid);
-        }
-        if (bgGvar != -1) {
-            int bgVal = gameGetGlobalVar(bgGvar);
-            if (bgVal != -1) {
-                gameDialogSetBackground(bgVal);
+            int gvarIdx = getBgGvarForScript(scriptBase);
+            if (gvarIdx != -1) {
+                bg = gameGetGlobalVar(gvarIdx);          // dynamic from GVAR
             }
+            if (bg == -1) {
+                bg = getStaticBgForScript(scriptBase);   // static fallback
+            }
+        }
+        if (bg != -1) {
+            gameDialogSetBackground(bg);
         }
     }
     // ====== END OVERRIDE ======

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -950,10 +950,10 @@ int _gdialogInitFromScript(int headFid, int reaction)
         if (gGameDialogSpeaker->sid != -1 && scriptGetBaseName(gGameDialogSpeaker->sid, scriptBase, sizeof(scriptBase))) {
             int gvarIdx = getBgGvarForScript(scriptBase);
             if (gvarIdx != -1) {
-                bg = gameGetGlobalVar(gvarIdx);          // dynamic from GVAR
+                bg = gameGetGlobalVar(gvarIdx); // dynamic from GVAR
             }
             if (bg == -1) {
-                bg = getStaticBgForScript(scriptBase);   // static fallback
+                bg = getStaticBgForScript(scriptBase); // static fallback
             }
         }
         if (bg != -1) {

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -952,6 +952,15 @@ int _gdialogInitFromScript(int headFid, int reaction)
         backgroundSoundDelete();
     }
 
+    // If this NPC has a background GVAR override, read it and apply
+    int bgGvarIndex = getHeadBgGvarOverride(gGameDialogSpeaker->pid);
+    if (bgGvarIndex != -1) {
+        int bgValue = gameGetGlobalVar(bgGvarIndex);
+        if (bgValue != -1) {          // -1 means "no override"
+            gameDialogSetBackground(bgValue);
+        }
+    }
+
     animationStop();
 
     _boxesWereDisabled = indicatorBarHide();

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -992,6 +992,8 @@ int _gdialogInitFromScript(int headFid, int reaction)
     gameDialogRedButtonsInit();
     gameDialogLittleRedButtonsInit();
 
+    gGameDialogHeadFid = headFid;
+
     _gdCreateHeadWindow();
     tickersAdd(gameDialogTicker);
     _gdSetupFidget(headFid, reaction);

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -2550,6 +2550,29 @@ int scriptGetScript(int sid, Script** scriptPtr)
     return -1;
 }
 
+bool scriptGetBaseName(int sid, char* dest, int destSize) {
+    if (sid == -1) return false;
+    Script* scr;
+    if (scriptGetScript(sid, &scr) != 0) return false;
+    if (scr->program == nullptr) return false;
+    const char* full = scr->program->name;
+    if (full == nullptr) return false;
+
+    // Find basename after last slash or backslash
+    const char* base = strrchr(full, '/');
+    const char* base2 = strrchr(full, '\\');
+    if (base2 > base) base = base2;
+    if (base) base++; else base = full;
+
+    // Remove .int extension
+    const char* dot = strrchr(base, '.');
+    size_t len = dot ? (dot - base) : strlen(base);
+    if (len + 1 > (size_t)destSize) return false;
+    strncpy(dest, base, len);
+    dest[len] = '\0';
+    return true;
+}
+
 // 0x4A5ED8
 static int scriptGetNewId(int scriptType)
 {

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -2550,7 +2550,8 @@ int scriptGetScript(int sid, Script** scriptPtr)
     return -1;
 }
 
-bool scriptGetBaseName(int sid, char* dest, int destSize) {
+bool scriptGetBaseName(int sid, char* dest, int destSize)
+{
     if (sid == -1) return false;
     Script* scr;
     if (scriptGetScript(sid, &scr) != 0) return false;
@@ -2562,7 +2563,10 @@ bool scriptGetBaseName(int sid, char* dest, int destSize) {
     const char* base = strrchr(full, '/');
     const char* base2 = strrchr(full, '\\');
     if (base2 > base) base = base2;
-    if (base) base++; else base = full;
+    if (base)
+        base++;
+    else
+        base = full;
 
     // Remove .int extension
     const char* dot = strrchr(base, '.');

--- a/src/scripts.h
+++ b/src/scripts.h
@@ -230,6 +230,8 @@ int scriptSetLocalVar(int sid, int var, ProgramValue& value);
 bool _scr_end_combat();
 int _scr_explode_scenery(Object* a1, int tile, int radius, int elevation);
 
+bool scriptGetBaseName(int sid, char* dest, int destSize);
+
 } // namespace fallout
 
 #endif /* SCRIPTS_H */


### PR DESCRIPTION
Allows an override to be assigned to any NPC that lacks a headFid (headFId == -1)

Override can be declared like this "casdy,3,3,3 npc_pid=0x1000059" in a heads_***.lst file

<img width="2240" height="1540" alt="Screenshot 2026-05-01 at 18 16 21" src="https://github.com/user-attachments/assets/868d04b2-67f0-4d61-9496-435380fa48a6" />


