### PR TITLE
Settings Fix

### DIFF
--- a/src/sfall_config.cc
+++ b/src/sfall_config.cc
@@ -524,12 +524,12 @@ bool modConfigInit(int argc, char** argv)
     configParseCommandLineArguments(&gModConfig, argc, argv);
     configChecker.check(gModConfig);
 
+    gModConfigInitialized = true;
+
     // read mod settings into main settings
     settingsFromModConfig();
 
     writeModFidsFile();
-
-    gModConfigInitialized = true;
 
     return true;
 }


### PR DESCRIPTION
settingsFromModConfig was returning early because gModConfigInitialized was false Moved gModConfigInitialized to its proper place before settingsFromModConfig Fixes bug where mod_*.cfg settings were not being written into settings.