### PR TITLE
Mod loading fixes

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -1954,11 +1954,6 @@ static int gameDbInit()
 
     createListsFolder();
 
-    // Restore CWD to data by calling dbOpen again
-    int master_db_handle = dbOpen(nullptr, settings.system.master_patches_path.c_str());
-
-    createListsFolder();
-
     return 0;
 }
 
@@ -2172,29 +2167,6 @@ ScopedGameMode::ScopedGameMode(int gameMode)
 ScopedGameMode::~ScopedGameMode()
 {
     GameMode::exitGameMode(gameMode);
-}
-
-static std::vector<std::string> listModsInFolder(const char* modsPath)
-{
-    std::vector<std::string> results;
-
-    char pattern[COMPAT_MAX_PATH];
-    snprintf(pattern, sizeof(pattern), "%s%c*", modsPath, DIR_SEPARATOR);
-
-    DirectoryFileFindData findData;
-    if (fileFindFirst(pattern, &findData)) {
-        do {
-            const char* name = fileFindGetName(&findData);
-            if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0) continue;
-            size_t len = strlen(name);
-            if (len >= 4 && compat_stricmp(name + len - 4, ".dat") == 0) {
-                results.push_back(name);
-            }
-        } while (fileFindNext(&findData));
-        findFindClose(&findData);
-    }
-
-    return results;
 }
 
 } // namespace fallout

--- a/src/main.cc
+++ b/src/main.cc
@@ -301,8 +301,6 @@ static int _main_load_new(char* mapFileName)
     wmMapMusicStart();
     paletteFadeTo(gPaletteWhite);
     windowDestroy(win);
-    colorPaletteLoad("color.pal");
-    paletteFadeTo(_cmap);
     return 0;
 }
 

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -2867,7 +2867,7 @@ static void load_mod_proto_list(int proto_type, const char* proto_type_name)
     for (int i = 0; i < file_count; i++) {
         // Extract mod name from filename: "items_MyMod.lst" ? "MyMod"
         const char* filename = mod_files[i];
-        char mod_name[64] = {0};
+        char mod_name[64] = { 0 };
 
         // Skip type name and underscore
         // Filename is like "items_testmod.lst", proto_type_name is "items"

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -2865,7 +2865,7 @@ static void load_mod_proto_list(int proto_type, const char* proto_type_name)
     int file_count = fileNameListInit(search_pattern, &mod_files);
 
     for (int i = 0; i < file_count; i++) {
-        // Extract mod name from filename: "items_MyMod.lst" ? "MyMod"
+        // Extract mod name from filename: "items_MyMod.lst" -> "MyMod"
         const char* filename = mod_files[i];
         char mod_name[64] = { 0 };
 

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -2854,49 +2854,45 @@ static void load_single_mod_proto_list(const char* list_path, const char* mod_na
  */
 static void load_mod_proto_list(int proto_type, const char* proto_type_name)
 {
+    // Build relative virtual pattern: "proto/items/items_*.lst"
     char search_pattern[COMPAT_MAX_PATH];
-    char path[COMPAT_MAX_PATH];
-
-    // Build path to proto directory for this type
-    proto_make_path(path, proto_type << 24); // Gets us: {base}/proto/{type}/
-
-    // {type}_{modname}.lst (e.g., items_testmod.lst)
-    snprintf(search_pattern, sizeof(search_pattern), "%s%c%s_*.lst",
-        path, DIR_SEPARATOR, proto_type_name);
+    snprintf(search_pattern, sizeof(search_pattern),
+        "proto%c%s%c%s_*.lst",
+        DIR_SEPARATOR, proto_type_name,
+        DIR_SEPARATOR, proto_type_name);
 
     char** mod_files = nullptr;
     int file_count = fileNameListInit(search_pattern, &mod_files);
 
     for (int i = 0; i < file_count; i++) {
-        // Extract mod name from filename: {type}_{modname}.lst -> {modname}
+        // Extract mod name from filename: "items_MyMod.lst" ? "MyMod"
         const char* filename = mod_files[i];
-        char mod_name[64] = { 0 };
+        char mod_name[64] = {0};
 
         // Skip type name and underscore
         // Filename is like "items_testmod.lst", proto_type_name is "items"
-        const char* mod_name_start = filename + strlen(proto_type_name) + 1; // Skip "items_"
-
-        // Copy mod name without .lst extension
-        const char* dot = strrchr(mod_name_start, '.');
-        if (dot) {
-            size_t mod_name_len = dot - mod_name_start;
-            if (mod_name_len > 0 && mod_name_len < sizeof(mod_name)) {
-                strncpy(mod_name, mod_name_start, mod_name_len);
-                mod_name[mod_name_len] = '\0';
+        const char* prefix = proto_type_name;
+        size_t prefix_len = strlen(prefix);
+        if (strncmp(filename, prefix, prefix_len) == 0 && filename[prefix_len] == '_') {
+            const char* mod_start = filename + prefix_len + 1;
+            const char* dot = strrchr(mod_start, '.');
+            size_t mod_len = dot ? (dot - mod_start) : strlen(mod_start);
+            if (mod_len > 0 && mod_len < sizeof(mod_name)) {
+                strncpy(mod_name, mod_start, mod_len);
+                mod_name[mod_len] = '\0';
             }
-        } else {
-            // No extension? Use the whole thing
-            strncpy(mod_name, mod_name_start, sizeof(mod_name) - 1);
         }
 
         if (strlen(mod_name) == 0) {
-            continue; // Skip invalid names
+            debugPrint("Warning: Could not extract mod name from %s\n", filename);
+            continue;
         }
 
-        // Build full path to the list file
+        // Build full virtual path to the .lst file
         char list_path[COMPAT_MAX_PATH];
-        snprintf(list_path, sizeof(list_path), "%s%c%s",
-            path, DIR_SEPARATOR, mod_files[i]);
+        snprintf(list_path, sizeof(list_path),
+            "proto%c%s%c%s",
+            DIR_SEPARATOR, proto_type_name, DIR_SEPARATOR, filename);
 
         load_single_mod_proto_list(list_path, mod_name, proto_type, proto_type_name);
     }

--- a/src/sfall_config.cc
+++ b/src/sfall_config.cc
@@ -621,7 +621,7 @@ bool modConfigInit(int argc, char** argv)
         const char* datName = folderMods[i];
         bool found = false;
         for (const auto& tm : allMods) {
-            if (strcmp(tm.info.datName, datName) == 0) {
+            if (compat_stricmp(tm.info.datName, datName) == 0) {
                 found = true;
                 break;
             }
@@ -706,6 +706,9 @@ bool modConfigInit(int argc, char** argv)
     gModConfigInitialized = true;
 
     settingsFromModConfig();
+
+    // Restore CWD to data by calling dbOpen again - critical, otherwise CWD will be mods folder
+    dbOpen(nullptr, settings.system.master_patches_path.c_str());
 
     return true;
 }

--- a/src/sfall_global_scripts.cc
+++ b/src/sfall_global_scripts.cc
@@ -36,29 +36,26 @@ static GlobalScriptsState* state = nullptr;
 bool sfall_gl_scr_init()
 {
     state = new (std::nothrow) GlobalScriptsState();
-    if (state == nullptr) {
-        return false;
+    if (state == nullptr) return false;
+
+    char pattern[COMPAT_MAX_PATH];
+    snprintf(pattern, sizeof(pattern), "scripts%cgl*.int", DIR_SEPARATOR);
+
+    char dirPrefix[COMPAT_MAX_PATH] = {0};
+    const char* lastSep = strrchr(pattern, DIR_SEPARATOR);
+    if (lastSep) {
+        size_t len = lastSep - pattern + 1;
+        strncpy(dirPrefix, pattern, len);
+        dirPrefix[len] = '\0';
     }
 
-    // Hardcoded pattern (cross?platform) formerly used: settings.mod_scripts.global_script_paths;
-    char pattern[COMPAT_MAX_PATH];
-    snprintf(pattern, sizeof(pattern),
-        "scripts%cgl*.int",
-        DIR_SEPARATOR);
-
-    // Extract drive and directory from the pattern (before the wildcard)
-    char drive[COMPAT_MAX_DRIVE];
-    char dir[COMPAT_MAX_DIR];
-    compat_splitpath(pattern, drive, dir, nullptr, nullptr);
-
-    // Get list of files matching the pattern
-    char** files;
+    char** files = nullptr;
     int filesLength = fileNameListInit(pattern, &files);
-    if (filesLength != 0) {
-        for (int index = 0; index < filesLength; ++index) {
-            char path[COMPAT_MAX_PATH];
-            compat_makepath(path, drive, dir, files[index], nullptr);
-            state->paths.push_back(std::string(path));
+    if (filesLength > 0) {
+        for (int i = 0; i < filesLength; ++i) {
+            char fullPath[COMPAT_MAX_PATH];
+            snprintf(fullPath, sizeof(fullPath), "%s%s", dirPrefix, files[i]);
+            state->paths.push_back(std::string(fullPath));
         }
         fileNameListFree(&files, 0);
     }
@@ -91,17 +88,13 @@ void sfall_gl_scr_exec_start_proc()
         if (program != nullptr) {
             GlobalScript scr;
             scr.program = program;
-
             for (int action = 0; action < SCRIPT_PROC_COUNT; action++) {
                 scr.procs[action] = programFindProcedure(program, gScriptProcNames[action]);
             }
-
             state->globalScripts.push_back(std::move(scr));
-
             programInterpret(program, -1);
         }
     }
-
     tickersAdd(sfall_gl_scr_process_input);
 }
 

--- a/src/sfall_global_scripts.cc
+++ b/src/sfall_global_scripts.cc
@@ -41,7 +41,7 @@ bool sfall_gl_scr_init()
     char pattern[COMPAT_MAX_PATH];
     snprintf(pattern, sizeof(pattern), "scripts%cgl*.int", DIR_SEPARATOR);
 
-    char dirPrefix[COMPAT_MAX_PATH] = {0};
+    char dirPrefix[COMPAT_MAX_PATH] = { 0 };
     const char* lastSep = strrchr(pattern, DIR_SEPARATOR);
     if (lastSep) {
         size_t len = lastSep - pattern + 1;


### PR DESCRIPTION
Fixes for mod .dat handling

1. Duplicate names for mods in mod manager - fixed
2. Save game failure for games with mods - fixed
3. Failure to load globals form .dat (and protos) - fixed