### PR TITLE
Run object start script on creation

### DIFF
--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -939,6 +939,13 @@ static void opCreateObject(Program* program)
         script->ownerId = object->id;
         script->owner = object;
         _scr_find_str_run_info(sid - 1, &(script->field_50), object->sid);
+
+        // Immediately load the script and run its start procedure
+        // This ensures the script is fully initialised and will be considered
+        // by the periodic critter script scheduler (_script_chk_critters).
+        if (!_isLoadingGame()) {
+            scriptExecProc(object->sid, SCRIPT_PROC_START);
+        }
     };
 
 out:

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -939,20 +939,6 @@ static void opCreateObject(Program* program)
         script->ownerId = object->id;
         script->owner = object;
         _scr_find_str_run_info(sid - 1, &(script->field_50), object->sid);
-
-        // Immediately load the script and run its start procedure
-        // This ensures the script is fully initialised and will be considered
-        // by the periodic critter script scheduler (_script_chk_critters).
-
-        // In the original Fallout 2, the first time any procedure of a script
-        // is executed, the script’s program is loaded and its `start` procedure is
-        // run implicitly. Without this, a newly created script may never be
-        // initialised in time, leading to a deadlock (e.g., the eyeball script
-        // that must re?enable the UI immediately). This call forces that same
-        // initialisation to happen right after creation.
-        if (!_isLoadingGame()) {
-            scriptExecProc(object->sid, SCRIPT_PROC_START);
-        }
     };
 
 out:

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -943,6 +943,13 @@ static void opCreateObject(Program* program)
         // Immediately load the script and run its start procedure
         // This ensures the script is fully initialised and will be considered
         // by the periodic critter script scheduler (_script_chk_critters).
+
+        // In the original Fallout 2, the first time any procedure of a script
+        // is executed, the script’s program is loaded and its `start` procedure is
+        // run implicitly. Without this, a newly created script may never be
+        // initialised in time, leading to a deadlock (e.g., the eyeball script
+        // that must re?enable the UI immediately). This call forces that same
+        // initialisation to happen right after creation.
         if (!_isLoadingGame()) {
             scriptExecProc(object->sid, SCRIPT_PROC_START);
         }

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -746,13 +746,8 @@ static void _script_chk_critters()
         if (extent != nullptr) {
             Script* script = &(extent->scripts[remaining]);
 
-            // Optional - verify script is valid
-            if (script->program != nullptr || (script->flags & SCRIPT_FLAG_LOADED) != 0) {
-                int proc = isInCombat() ? SCRIPT_PROC_COMBAT : SCRIPT_PROC_CRITTER;
-                scriptExecProc(script->sid, proc);
-            } else {
-                debugPrint("_script_chk_critters: skipping unloaded script sid=%d\n", script->sid);
-            }
+            int proc = isInCombat() ? SCRIPT_PROC_COMBAT : SCRIPT_PROC_CRITTER;
+            scriptExecProc(script->sid, proc);
         }
     }
 }


### PR DESCRIPTION
Removed guard to allow lazy loading of scripts, matching original behaviour.