### PR TITLE
Extract mod music files to data on init

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -94,6 +94,7 @@ static int gameDbInit();
 static void showSplash();
 static int loadModGlobalVars();
 static void generateGVarReport();
+static void extractModMusicFiles();
 
 // 0x501C9C
 static char _aGame_0[] = "game\\";
@@ -1954,6 +1955,9 @@ static int gameDbInit()
 
     createListsFolder();
 
+    // Extract all music files from mods into data
+    extractModMusicFiles();
+
     return 0;
 }
 
@@ -2131,6 +2135,49 @@ int gameSetGlobalPointer(int var, void* value)
     gGameGlobalPointers[var] = value;
 
     return 0;
+}
+
+static void extractModMusicFiles() {
+    char** files = nullptr;
+    int fileCount = fileNameListInit("sound/music/*.acm", &files);
+    debugPrint("extractModMusicFiles: found %d .acm files in sound/music/\n", fileCount);
+
+    for (int i = 0; i < fileCount; i++) {
+        const char* baseName = files[i];
+        
+        char virtualPath[COMPAT_MAX_PATH];
+        snprintf(virtualPath, sizeof(virtualPath), "sound/music/%s", baseName);
+        
+        char destPath[COMPAT_MAX_PATH];
+        snprintf(destPath, sizeof(destPath), "%sdata%csound%cmusic%c%s",
+                 _cd_path_base, DIR_SEPARATOR, DIR_SEPARATOR, DIR_SEPARATOR, baseName);
+        
+        File* src = fileOpen(virtualPath, "rb");
+        if (!src) {
+            debugPrint("Failed to open VFS file: %s\n", virtualPath);
+            continue;
+        }
+        
+        // Always overwrite, respecting mod load order
+        File* dst = fileOpen(destPath, "wb");
+        if (!dst) {
+            debugPrint("Failed to create destination: %s\n", destPath);
+            fileClose(src);
+            continue;
+        }
+        
+        char buf[8192];
+        size_t bytes;
+        while ((bytes = fileRead(buf, 1, sizeof(buf), src)) > 0) {
+            fileWrite(buf, 1, bytes, dst);
+        }
+        
+        fileClose(dst);
+        fileClose(src);
+        debugPrint("Extracted: %s -> %s\n", virtualPath, destPath);
+    }
+    
+    fileNameListFree(&files, fileCount);
 }
 
 int GameMode::currentGameMode = 0;

--- a/src/game.cc
+++ b/src/game.cc
@@ -2140,14 +2140,14 @@ int gameSetGlobalPointer(int var, void* value)
 static void extractModMusicFiles()
 {
     char** files = nullptr;
-    int fileCount = fileNameListInit("sound/music/*.acm", &files);
+    int fileCount = fileNameListInit("sound\\music\\*.acm", &files);
     debugPrint("extractModMusicFiles: found %d .acm files in sound/music/\n", fileCount);
 
     for (int i = 0; i < fileCount; i++) {
         const char* baseName = files[i];
 
         char virtualPath[COMPAT_MAX_PATH];
-        snprintf(virtualPath, sizeof(virtualPath), "sound/music/%s", baseName);
+        snprintf(virtualPath, sizeof(virtualPath), "sound\\music\\%s", baseName);
 
         char destPath[COMPAT_MAX_PATH];
         snprintf(destPath, sizeof(destPath), "%sdata%csound%cmusic%c%s",

--- a/src/game.cc
+++ b/src/game.cc
@@ -2137,27 +2137,28 @@ int gameSetGlobalPointer(int var, void* value)
     return 0;
 }
 
-static void extractModMusicFiles() {
+static void extractModMusicFiles()
+{
     char** files = nullptr;
     int fileCount = fileNameListInit("sound/music/*.acm", &files);
     debugPrint("extractModMusicFiles: found %d .acm files in sound/music/\n", fileCount);
 
     for (int i = 0; i < fileCount; i++) {
         const char* baseName = files[i];
-        
+
         char virtualPath[COMPAT_MAX_PATH];
         snprintf(virtualPath, sizeof(virtualPath), "sound/music/%s", baseName);
-        
+
         char destPath[COMPAT_MAX_PATH];
         snprintf(destPath, sizeof(destPath), "%sdata%csound%cmusic%c%s",
-                 _cd_path_base, DIR_SEPARATOR, DIR_SEPARATOR, DIR_SEPARATOR, baseName);
-        
+            _cd_path_base, DIR_SEPARATOR, DIR_SEPARATOR, DIR_SEPARATOR, baseName);
+
         File* src = fileOpen(virtualPath, "rb");
         if (!src) {
             debugPrint("Failed to open VFS file: %s\n", virtualPath);
             continue;
         }
-        
+
         // Always overwrite, respecting mod load order
         File* dst = fileOpen(destPath, "wb");
         if (!dst) {
@@ -2165,18 +2166,18 @@ static void extractModMusicFiles() {
             fileClose(src);
             continue;
         }
-        
+
         char buf[8192];
         size_t bytes;
         while ((bytes = fileRead(buf, 1, sizeof(buf), src)) > 0) {
             fileWrite(buf, 1, bytes, dst);
         }
-        
+
         fileClose(dst);
         fileClose(src);
         debugPrint("Extracted: %s -> %s\n", virtualPath, destPath);
     }
-    
+
     fileNameListFree(&files, fileCount);
 }
 


### PR DESCRIPTION
Add extractModMusicFiles() and call it from gameDbInit() to copy .acm music files found in the virtual sound/music/ VFS into the game's data/sound/music/ directory at startup. The new helper enumerates files with fileNameListInit("sound/music/*.acm"), opens each VFS file and writes it to a destination under _cd_path_base (overwriting to respect mod load order), logs failures and successes, and frees the file list. Also adds the function prototype near other statics.

This allows mods to pack all their files, even music, directly into one .dat file.

Currently, the windows version is CTD on start - macOS is fine.