### PR TITLE
Worldmap Fade from Movie

### DIFF
--- a/src/game_movie.cc
+++ b/src/game_movie.cc
@@ -319,13 +319,12 @@ int gameMoviePlay(int movie, int flags)
         if (!subtitlesEnabled) {
             colorPaletteLoad("color.pal");
         }
-        
-        if(!GameMode::isInGameMode(GameMode::kMap)) // Need to exclude the fade from the worldmap, otherwise we fade into it - the fade is handled at town entry.
+
+        if (!GameMode::isInGameMode(GameMode::kMap)) // Need to exclude the fade from the worldmap, otherwise we fade into it - the fade is handled at town entry.
         {
             paletteFadeTo(_cmap);
         }
         gGameMovieFaded = false;
-
     }
 
     gGameMovieIsPlaying = false;

--- a/src/game_movie.cc
+++ b/src/game_movie.cc
@@ -319,9 +319,13 @@ int gameMoviePlay(int movie, int flags)
         if (!subtitlesEnabled) {
             colorPaletteLoad("color.pal");
         }
-
-        paletteFadeTo(_cmap);
+        
+        if(!GameMode::isInGameMode(GameMode::kMap)) // Need to exclude the fade from the worldmap, otherwise we fade into it - the fade is handled at town entry.
+        {
+            paletteFadeTo(_cmap);
+        }
         gGameMovieFaded = false;
+
     }
 
     gGameMovieIsPlaying = false;


### PR DESCRIPTION
Fix for fade in from Movie on worldmap
This prevents a fade back to worldmap, then sharp cut into the area map. Must watch out for other cases - fadein/fadeout is a mess, thanks to the scroll handling
