### PR TITLE
Rename mod.cfg to game.cfg

### DIFF
--- a/src/sfall_config.cc
+++ b/src/sfall_config.cc
@@ -672,7 +672,7 @@ bool modConfigInit(int argc, char** argv)
     // Write back mods_order.txt (new pipe format)
     writeModsOrderFile(gLoadedMods, gLoadedModsCount);
 
-    // Read global mod.cfg and enabled mods' configs (for settings)
+    // Read global game.cfg and enabled mods' configs (for settings)
     char cfgMainPath[COMPAT_MAX_PATH];
     snprintf(cfgMainPath, sizeof(cfgMainPath), "data%c%s", DIR_SEPARATOR, MOD_CONFIG_FILE_NAME);
     configRead(&gModConfig, cfgMainPath, true);
@@ -681,7 +681,7 @@ bool modConfigInit(int argc, char** argv)
         const ModInfo* info = &gLoadedMods[i];
         if (info->enabled && info->name[0] != '\0') {
             char modCfgPath[COMPAT_MAX_PATH];
-            snprintf(modCfgPath, sizeof(modCfgPath), "data%cmod_%s.cfg", DIR_SEPARATOR, info->name);
+            snprintf(modCfgPath, sizeof(modCfgPath), "data%cgame_%s.cfg", DIR_SEPARATOR, info->name);
             configRead(&gModConfig, modCfgPath, true);
         }
     }

--- a/src/sfall_config.h
+++ b/src/sfall_config.h
@@ -6,13 +6,13 @@
 
 namespace fallout {
 
-#define MOD_CONFIG_FILE_NAME "mod.cfg" // set this to mod 'configuration' file, kept in dat - one level down - new name "fission.cfg"?
+#define MOD_CONFIG_FILE_NAME "game.cfg" // set this to mod 'configuration' file, kept in dat - one level down - new name "fission.cfg"?
 
 // Changed category headers for better crouping in .cfg file
 #define MOD_CONFIG_SETTINGS_KEY "mod_settings"
 #define MOD_CONFIG_SCRIPTS_KEY "mod_scripts"
 
-// ---- mod.cfg settings ----
+// ---- game.cfg settings ----
 #define MOD_CONFIG_VERSION_STRING "VersionString"
 #define MOD_CONFIG_START_YEAR "StartYear"
 #define MOD_CONFIG_START_MONTH "StartMonth"
@@ -86,7 +86,7 @@ namespace fallout {
 #define MOD_CONFIG_IFACE_BAR_SIDE_ART "IFACE_BAR_SIDE_ART"
 #define MOD_CONFIG_IFACE_BAR_SIDES_ORI "IFACE_BAR_SIDES_ORI"
 
-// ---- mod.cfg settings default values ----
+// ---- game.cfg settings default values ----
 #define MOD_CONFIG_DEFAULT_START_YEAR 2241
 #define MOD_CONFIG_DEFAULT_START_MONTH 6
 #define MOD_CONFIG_DEFAULT_START_DAY 24


### PR DESCRIPTION
game.cfg and game_<mod_name>.cfg files will now contain all game settings and per setting overrides (in game_<mod_name>.cfg) mod_<mod_name>.cfg will only contain mod information.

This will prevent confusion and accidental overrides from mod.cfg - most (nearly all) will only need the mod_<mod_name>.cfg file, an will not have a game_<mod_name>.cfg file.
