### PR TITLE
Crit Animation + Dialogue Window Fixes

### DIFF
--- a/src/art.cc
+++ b/src/art.cc
@@ -2288,11 +2288,11 @@ int artCritterFidShouldRun(int fid)
 }
 
 // 0x4199D4
+// fixed for death_animation crash
 int artAliasFid(int fid)
 {
     int type = FID_TYPE(fid);
     int anim = FID_ANIM_TYPE(fid);
-
     if (type == OBJ_TYPE_CRITTER) {
         if (anim == ANIM_ELECTRIFY
             || anim == ANIM_BURNED_TO_NOTHING
@@ -2303,13 +2303,26 @@ int artAliasFid(int fid)
             || anim == ANIM_FIRE_DANCE
             || anim == ANIM_CALLED_SHOT_PIC) {
 
-            int aliasIndex = _anon_alias[artGetIndex(fid)];
-            // Build a new FID with the alias index, preserving rotation, weapon code, and animation.
-            int newFid = buildFid(type, aliasIndex, anim, (fid & 0xF000) >> 12, FID_ROTATION(fid));
-            return newFid;
+            int idx = artGetIndex(fid);          // full index of original (0-8191)
+            int alias = _anon_alias[idx];        // full alias index (0-8191)
+
+            // Extract rotation bits (bits 28-30) from original fid
+            int rotation_bits = fid & 0x70000000;
+            // Weapon code bits (bits 12-15)
+            int weapon_bits = fid & 0xF000;
+            // Object type (critter) = 1 << 24 = 0x1000000
+            int type_bits = OBJ_TYPE_CRITTER << 24;
+            // Animation bits (bits 16-23)
+            int anim_bits = (anim << 16) & 0xFF0000;
+
+            // Alias index: split into low 12 bits and high bit if >=4096
+            int alias_low = alias & 0xFFF;
+            int alias_high = (alias >= 4096) ? 0x80000000 : 0;
+
+            // Combine all parts
+            return rotation_bits | type_bits | anim_bits | weapon_bits | alias_low | alias_high;
         }
     }
-
     return -1;
 }
 

--- a/src/art.cc
+++ b/src/art.cc
@@ -2303,8 +2303,8 @@ int artAliasFid(int fid)
             || anim == ANIM_FIRE_DANCE
             || anim == ANIM_CALLED_SHOT_PIC) {
 
-            int idx = artGetIndex(fid);          // full index of original (0-8191)
-            int alias = _anon_alias[idx];        // full alias index (0-8191)
+            int idx = artGetIndex(fid); // full index of original (0-8191)
+            int alias = _anon_alias[idx]; // full alias index (0-8191)
 
             // Extract rotation bits (bits 28-30) from original fid
             int rotation_bits = fid & 0x70000000;

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -6848,7 +6848,7 @@ static void damageModCalculateYaam(DamageCalculationContext* context)
         damage -= damage * damageResistance / 100;
 
         if (damage > 0) {
-            *context->damagePtr += damage;
+            context->damagePtr += damage;
         }
     }
 }

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -4629,7 +4629,7 @@ int _gdialog_window_create()
         int dialogSubwindowX = (screenGetWidth() - GAME_DIALOG_WINDOW_WIDTH) / 2;
         int dialogSubwindowY = (screenGetHeight() - GAME_DIALOG_WINDOW_HEIGHT) / 2 + GAME_DIALOG_WINDOW_HEIGHT - _dialogue_subwin_len;
         // Set window to hidden on dialogue start for 'smooth' appearence
-        if (_dialogue_just_started){
+        if (_dialogue_just_started) {
             gGameDialogWindow = windowCreate(dialogSubwindowX, dialogSubwindowY, screenWidth, _dialogue_subwin_len, 256, WINDOW_DONT_MOVE_TOP | WINDOW_HIDDEN);
         } else {
             gGameDialogWindow = windowCreate(dialogSubwindowX, dialogSubwindowY, screenWidth, _dialogue_subwin_len, 256, WINDOW_DONT_MOVE_TOP);

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -4628,7 +4628,12 @@ int _gdialog_window_create()
 
         int dialogSubwindowX = (screenGetWidth() - GAME_DIALOG_WINDOW_WIDTH) / 2;
         int dialogSubwindowY = (screenGetHeight() - GAME_DIALOG_WINDOW_HEIGHT) / 2 + GAME_DIALOG_WINDOW_HEIGHT - _dialogue_subwin_len;
-        gGameDialogWindow = windowCreate(dialogSubwindowX, dialogSubwindowY, screenWidth, _dialogue_subwin_len, 256, WINDOW_DONT_MOVE_TOP | WINDOW_HIDDEN);
+        // Set window to hidden on dialogue start for 'smooth' appearence
+        if (_dialogue_just_started){
+            gGameDialogWindow = windowCreate(dialogSubwindowX, dialogSubwindowY, screenWidth, _dialogue_subwin_len, 256, WINDOW_DONT_MOVE_TOP | WINDOW_HIDDEN);
+        } else {
+            gGameDialogWindow = windowCreate(dialogSubwindowX, dialogSubwindowY, screenWidth, _dialogue_subwin_len, 256, WINDOW_DONT_MOVE_TOP);
+        }
         if (gGameDialogWindow != -1) {
 
             unsigned char* windowBuf = windowGetBuffer(gGameDialogWindow);
@@ -4640,6 +4645,7 @@ int _gdialog_window_create()
             _gdialog_buttons[0] = buttonCreate(gGameDialogWindow, 593, 41, 14, 14, -1, -1, -1, -1, _redButtonNormalFrmImage.getData(), _redButtonPressedFrmImage.getData(), nullptr, BUTTON_FLAG_TRANSPARENT);
 
             if (_dialogue_just_started) {
+                windowRefresh(gGameDialogBackgroundWindow);
                 _gdialog_scroll_subwin(gGameDialogWindow, true, backgroundFrmData, windowBuf, nullptr, _dialogue_subwin_len, true);
                 _dialogue_just_started = 0;
             } else {


### PR DESCRIPTION
Various small fixes - dialogue window and crit animation

Crit animation had incorrectly assigned high bit
Dialgoue window incorrectly 'hidden' (for smooth show) on subsequent uses (after first appearance)