### PR TITLE
Fix Heap Corruption

### DIFF
--- a/src/animation.cc
+++ b/src/animation.cc
@@ -1955,6 +1955,9 @@ int pathfinderFindPath(Object* object, int from, int to, unsigned char* rotation
 
         for (int rotation = 0; rotation < ROTATION_COUNT; rotation++) {
             int tile = tileGetTileInDirection(temp.tile, rotation, 1);
+            if (tile < 0 || tile >= HEX_GRID_SIZE) {
+                continue;
+            }
             int bit = 1 << (tile & 7);
             if ((gPathfinderProcessedTiles[tile / 8] & bit) != 0) {
                 continue;
@@ -1974,6 +1977,9 @@ int pathfinderFindPath(Object* object, int from, int to, unsigned char* rotation
                 if (gOpenPathNodeList[v25].tile == -1) {
                     break;
                 }
+            }
+            if (v25 == PATH_NODE_CAPACITY) {
+                return 0;
             }
 
             openPathNodeListLength += 1;

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1829,7 +1829,7 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
     int requiredSize = (arrowFrmWidth + menuItemFrmWidth) * menuItemFrmHeight;
     if (requiredSize > gGameMouseActionPickFrmDataSize) {
         debugPrint("gameMouseRenderPrimaryAction: buffer too small! needed %d, have %d\n",
-                   requiredSize, gGameMouseActionPickFrmDataSize);
+            requiredSize, gGameMouseActionPickFrmDataSize);
         artUnlock(arrowFrmHandle);
         artUnlock(menuItemFrmHandle);
         return -1;
@@ -1969,7 +1969,7 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
     int requiredSize = requiredWidth * requiredHeight;
     if (requiredSize > gGameMouseActionMenuFrmDataSize) {
         debugPrint("gameMouseRenderActionMenuItems: buffer too small! needed %d, have %d\n",
-                   requiredSize, gGameMouseActionMenuFrmDataSize);
+            requiredSize, gGameMouseActionMenuFrmDataSize);
         artUnlock(arrowFrmHandle);
         for (int index = 0; index < menuItemsLength; index++) {
             artUnlock(menuItemFrmHandles[index]);
@@ -2021,8 +2021,7 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
     }
 
     // Verify arrowFrmDest is within bounds
-    if (arrowFrmDest < gGameMouseActionMenuFrmData ||
-        arrowFrmDest + (arrowWidth * arrowHeight) > gGameMouseActionMenuFrmData + gGameMouseActionMenuFrmDataSize) {
+    if (arrowFrmDest < gGameMouseActionMenuFrmData || arrowFrmDest + (arrowWidth * arrowHeight) > gGameMouseActionMenuFrmData + gGameMouseActionMenuFrmDataSize) {
         debugPrint("gameMouseRenderActionMenuItems: arrowFrmDest out of bounds!\n");
         artUnlock(arrowFrmHandle);
         for (int index = 0; index < menuItemsLength; index++) {

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -12,6 +12,7 @@
 #include "color.h"
 #include "combat.h"
 #include "critter.h"
+#include "debug.h"
 #include "draw.h"
 #include "game.h"
 #include "game_sound.h"
@@ -1807,8 +1808,7 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
     Art* arrowFrm = artLock(arrowFid, &arrowFrmHandle);
     if (arrowFrm == nullptr) {
         artUnlock(menuItemFrmHandle);
-        // FIXME: Why this is success?
-        return 0;
+        return -1;
     }
 
     unsigned char* arrowFrmData = artGetFrameData(arrowFrm, 0, 0);
@@ -1818,6 +1818,22 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
     unsigned char* menuItemFrmData = artGetFrameData(menuItemFrm, 0, 0);
     int menuItemFrmWidth = artGetWidth(menuItemFrm, 0, 0);
     int menuItemFrmHeight = artGetHeight(menuItemFrm, 0, 0);
+
+    // Safety checks
+    if (gGameMouseActionPickFrmData == nullptr || gGameMouseActionPickFrmDataSize == 0) {
+        artUnlock(arrowFrmHandle);
+        artUnlock(menuItemFrmHandle);
+        return -1;
+    }
+
+    int requiredSize = (arrowFrmWidth + menuItemFrmWidth) * menuItemFrmHeight;
+    if (requiredSize > gGameMouseActionPickFrmDataSize) {
+        debugPrint("gameMouseRenderPrimaryAction: buffer too small! needed %d, have %d\n",
+                   requiredSize, gGameMouseActionPickFrmDataSize);
+        artUnlock(arrowFrmHandle);
+        artUnlock(menuItemFrmHandle);
+        return -1;
+    }
 
     unsigned char* arrowFrmDest = gGameMouseActionPickFrmData;
     unsigned char* menuItemFrmDest = gGameMouseActionPickFrmData;
@@ -1831,6 +1847,13 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
     int maxX = x + menuItemFrmWidth + arrowFrmWidth - 1;
     int maxY = y + menuItemFrmHeight - 1;
     int shiftY = maxY - height + 2;
+
+    if (shiftY < 0) shiftY = 0;
+    if (shiftY >= gGameMouseActionPickFrmHeight - arrowFrmHeight) {
+        artUnlock(arrowFrmHandle);
+        artUnlock(menuItemFrmHandle);
+        return -1;
+    }
 
     if (maxX < width) {
         menuItemFrmDest += arrowFrmWidth;
@@ -1931,6 +1954,29 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
     int menuItemWidth = artGetWidth(menuItemFrms[0], 0, 0);
     int menuItemHeight = artGetHeight(menuItemFrms[0], 0, 0);
 
+    // Check if gGameMouseActionMenuFrmData is valid
+    if (gGameMouseActionMenuFrmData == nullptr || gGameMouseActionMenuFrmDataSize == 0) {
+        artUnlock(arrowFrmHandle);
+        for (int index = 0; index < menuItemsLength; index++) {
+            artUnlock(menuItemFrmHandles[index]);
+        }
+        return -1;
+    }
+
+    // Check total buffer size
+    int requiredWidth = arrowWidth + menuItemWidth;
+    int requiredHeight = menuItemsLength * menuItemHeight;
+    int requiredSize = requiredWidth * requiredHeight;
+    if (requiredSize > gGameMouseActionMenuFrmDataSize) {
+        debugPrint("gameMouseRenderActionMenuItems: buffer too small! needed %d, have %d\n",
+                   requiredSize, gGameMouseActionMenuFrmDataSize);
+        artUnlock(arrowFrmHandle);
+        for (int index = 0; index < menuItemsLength; index++) {
+            artUnlock(menuItemFrmHandles[index]);
+        }
+        return -1;
+    }
+
     _gmouse_3d_menu_frame_hot_x = 0;
     _gmouse_3d_menu_frame_hot_y = 0;
 
@@ -1939,6 +1985,12 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
 
     int maxY = y + menuItemsLength * menuItemHeight - 1;
     int shiftY = maxY - height + 2;
+
+    // Clamp shiftY
+    int maxShiftY = gGameMouseActionMenuFrmHeight - arrowHeight;
+    if (shiftY > maxShiftY) shiftY = maxShiftY;
+    if (shiftY < 0) shiftY = 0;
+
     unsigned char* arrowFrmDest = gGameMouseActionMenuFrmData;
     unsigned char* menuItemFrmDest = arrowFrmDest;
 
@@ -1968,13 +2020,33 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
         }
     }
 
+    // Verify arrowFrmDest is within bounds
+    if (arrowFrmDest < gGameMouseActionMenuFrmData ||
+        arrowFrmDest + (arrowWidth * arrowHeight) > gGameMouseActionMenuFrmData + gGameMouseActionMenuFrmDataSize) {
+        debugPrint("gameMouseRenderActionMenuItems: arrowFrmDest out of bounds!\n");
+        artUnlock(arrowFrmHandle);
+        for (int index = 0; index < menuItemsLength; index++) {
+            artUnlock(menuItemFrmHandles[index]);
+        }
+        return -1;
+    }
+
     memset(gGameMouseActionMenuFrmData, 0, gGameMouseActionMenuFrmDataSize);
-    blitBufferToBuffer(arrowData, arrowWidth, arrowHeight, arrowWidth, arrowFrmDest, gGameMouseActionPickFrmWidth);
+    blitBufferToBuffer(arrowData, arrowWidth, arrowHeight, arrowWidth, arrowFrmDest, gGameMouseActionMenuFrmWidth);
 
     unsigned char* dest = menuItemFrmDest;
     for (int index = 0; index < menuItemsLength; index++) {
+        // Verify dest is within bounds for each menu item
+        if (dest + (menuItemWidth * menuItemHeight) > gGameMouseActionMenuFrmData + gGameMouseActionMenuFrmDataSize) {
+            debugPrint("gameMouseRenderActionMenuItems: dest out of bounds at index %d!\n", index);
+            artUnlock(arrowFrmHandle);
+            for (int j = 0; j < menuItemsLength; j++) {
+                artUnlock(menuItemFrmHandles[j]);
+            }
+            return -1;
+        }
         unsigned char* data = artGetFrameData(menuItemFrms[index], 0, 0);
-        blitBufferToBuffer(data, menuItemWidth, menuItemHeight, menuItemWidth, dest, gGameMouseActionPickFrmWidth);
+        blitBufferToBuffer(data, menuItemWidth, menuItemHeight, menuItemWidth, dest, gGameMouseActionMenuFrmWidth);
         dest += gGameMouseActionMenuFrmWidth * menuItemHeight;
     }
 
@@ -2003,6 +2075,10 @@ int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
         return -1;
     }
 
+    if (_gmouse_3d_menu_actions_start == nullptr) {
+        return -1;
+    }
+
     CacheEntry* handle;
     int fid = buildFid(OBJ_TYPE_INTERFACE, gGameMouseActionMenuItemFrmIds[gGameMouseActionMenuItems[gGameMouseActionMenuHighlightedItemIndex]], 0, 0, 0);
     Art* art = artLock(fid, &handle);
@@ -2022,8 +2098,10 @@ int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
         return -1;
     }
 
+    int highlightWidth = artGetWidth(art, 0, 0);
+    int highlightHeight = artGetHeight(art, 0, 0);
     data = artGetFrameData(art, 0, 0);
-    blitBufferToBuffer(data, width, height, width, _gmouse_3d_menu_actions_start + gGameMouseActionMenuFrmWidth * height * menuItemIndex, gGameMouseActionMenuFrmWidth);
+    blitBufferToBuffer(data, highlightWidth, highlightHeight, highlightWidth, _gmouse_3d_menu_actions_start + gGameMouseActionMenuFrmWidth * highlightHeight * menuItemIndex, gGameMouseActionMenuFrmWidth);
     artUnlock(handle);
 
     gGameMouseActionMenuHighlightedItemIndex = menuItemIndex;
@@ -2286,37 +2364,56 @@ err:
 // 0x44DE44
 void gameMouseActionMenuFree()
 {
+    // Unlock BouncingCursor
     if (gGameMouseBouncingCursorFrmHandle != INVALID_CACHE_ENTRY) {
         artUnlock(gGameMouseBouncingCursorFrmHandle);
     }
     gGameMouseBouncingCursorFrm = nullptr;
     gGameMouseBouncingCursorFrmHandle = INVALID_CACHE_ENTRY;
+    gGameMouseBouncingCursorFrmData = nullptr;
+    gGameMouseBouncingCursorFrmWidth = 0;
+    gGameMouseBouncingCursorFrmHeight = 0;
+    gGameMouseBouncingCursorFrmDataSize = 0;
 
+    // Unlock HexCursor
     if (gGameMouseHexCursorFrmHandle != INVALID_CACHE_ENTRY) {
         artUnlock(gGameMouseHexCursorFrmHandle);
     }
     gGameMouseHexCursorFrm = nullptr;
     gGameMouseHexCursorFrmHandle = INVALID_CACHE_ENTRY;
+    gGameMouseHexCursorFrmData = nullptr;
+    gGameMouseHexCursorFrmWidth = 0;
+    gGameMouseHexCursorHeight = 0;
+    gGameMouseHexCursorDataSize = 0;
 
+    // Unlock ActionHit
     if (gGameMouseActionHitFrmHandle != INVALID_CACHE_ENTRY) {
         artUnlock(gGameMouseActionHitFrmHandle);
     }
     gGameMouseActionHitFrm = nullptr;
     gGameMouseActionHitFrmHandle = INVALID_CACHE_ENTRY;
+    gGameMouseActionHitFrmData = nullptr;
+    gGameMouseActionHitFrmWidth = 0;
+    gGameMouseActionHitFrmHeight = 0;
+    gGameMouseActionHitFrmDataSize = 0;
 
+    // Unlock ActionMenu
     if (gGameMouseActionMenuFrmHandle != INVALID_CACHE_ENTRY) {
         artUnlock(gGameMouseActionMenuFrmHandle);
     }
     gGameMouseActionMenuFrm = nullptr;
     gGameMouseActionMenuFrmHandle = INVALID_CACHE_ENTRY;
+    gGameMouseActionMenuFrmData = nullptr;
+    gGameMouseActionMenuFrmWidth = 0;
+    gGameMouseActionMenuFrmHeight = 0;
+    gGameMouseActionMenuFrmDataSize = 0;
 
+    // Unlock ActionPick
     if (gGameMouseActionPickFrmHandle != INVALID_CACHE_ENTRY) {
         artUnlock(gGameMouseActionPickFrmHandle);
     }
-
     gGameMouseActionPickFrm = nullptr;
     gGameMouseActionPickFrmHandle = INVALID_CACHE_ENTRY;
-
     gGameMouseActionPickFrmData = nullptr;
     gGameMouseActionPickFrmWidth = 0;
     gGameMouseActionPickFrmHeight = 0;

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -5799,7 +5799,8 @@ static void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
 
     if (gameMouseRenderActionMenuItems(x, y, actionMenuItems, actionMenuItemsLength,
             windowDescription->width + inventoryWindowX,
-            windowDescription->height + inventoryWindowY) == -1) {
+            windowDescription->height + inventoryWindowY)
+        == -1) {
         inventorySetCursor(INVENTORY_WINDOW_CURSOR_ARROW);
         return;
     }

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -5797,9 +5797,12 @@ static void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
     int inventoryWindowX = windowRect.left;
     int inventoryWindowY = windowRect.top;
 
-    gameMouseRenderActionMenuItems(x, y, actionMenuItems, actionMenuItemsLength,
-        windowDescription->width + inventoryWindowX,
-        windowDescription->height + inventoryWindowY);
+    if (gameMouseRenderActionMenuItems(x, y, actionMenuItems, actionMenuItemsLength,
+            windowDescription->width + inventoryWindowX,
+            windowDescription->height + inventoryWindowY) == -1) {
+        inventorySetCursor(INVENTORY_WINDOW_CURSOR_ARROW);
+        return;
+    }
 
     InventoryCursorData* cursorData = &(gInventoryCursorData[INVENTORY_WINDOW_CURSOR_MENU]);
 

--- a/src/obj_types.h
+++ b/src/obj_types.h
@@ -280,15 +280,15 @@ typedef struct Object {
     int fid; // obj_fid
     int flags; // obj_flags
     int elevation; // obj_elev
-    ObjectData data;
     int pid; // obj_pid
     int cid; // obj_cid
     int lightDistance; // obj_light_distance
     int lightIntensity; // obj_light_intensity
     int outline; // obj_outline
     int sid; // obj_sid
-    Object* owner;
     int scriptIndex;
+    Object* owner;
+    ObjectData data;
 } Object;
 
 typedef struct ObjectListNode {


### PR DESCRIPTION
- Various fixes for a heap corruption bug
- Main fix is the misnamed pitch variable in game_mouse (gGameMouseActionMenuFrmWidth)
- Add bounds and capacity checks to pathfinder to avoid out-of-range tile indices and prevent overflow of the path node list.
- Harden game_mouse rendering: include debug, return -1 on art lock failure, validate frame buffers/sizes, clamp shifts, check destination bounds, use correct blit widths, and fix highlight blit sizing to use actual art dimensions.
- Improve resource cleanup in gameMouseActionMenuFree by unlocking handles and zeroing related data/size/width/height fields to avoid stale pointers.
- Propagate error handling to inventory context menu to reset cursor on render failure.
- Reorder Object fields in obj_types.h (owner and data) to maintain expected struct layout.

