### PR TITLE
Use correct loot background for inventory menus

### DIFF
--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -5600,6 +5600,8 @@ static void inventoryWindowOpenSortContextMenu(int keyCode, int inventoryWindowT
         int backgroundFid;
         if (inventoryWindowType == INVENTORY_WINDOW_TYPE_NORMAL) {
             backgroundFid = buildFid(OBJ_TYPE_INTERFACE, gCurrentInventoryBackgroundFrm, 0, 0, 0);
+        } else if (inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT) {
+            backgroundFid = buildFid(OBJ_TYPE_INTERFACE, gCurrentLootBackgroundFrm, 0, 0, 0);
         } else {
             backgroundFid = buildFid(OBJ_TYPE_INTERFACE, windowDesc->frmId, 0, 0, 0);
         }
@@ -5895,6 +5897,8 @@ static void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
         int backgroundFid;
         if (inventoryWindowType == INVENTORY_WINDOW_TYPE_NORMAL) {
             backgroundFid = buildFid(OBJ_TYPE_INTERFACE, gCurrentInventoryBackgroundFrm, 0, 0, 0);
+        } else if (inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT) {
+            backgroundFid = buildFid(OBJ_TYPE_INTERFACE, gCurrentLootBackgroundFrm, 0, 0, 0);
         } else {
             backgroundFid = buildFid(OBJ_TYPE_INTERFACE, windowDescription->frmId, 0, 0, 0);
         }


### PR DESCRIPTION
- Handle INVENTORY_WINDOW_TYPE_LOOT when selecting the background FID in inventoryWindowOpenSortContextMenu and inventoryWindowOpenContextMenu. 
- For loot windows the code now uses gCurrentLootBackgroundFrm so the correct loot background is shown for context and sort menus.

Fixes #107 
