### PR TITLE
Multidex improvements

### DIFF
--- a/src/interface.cc
+++ b/src/interface.cc
@@ -58,6 +58,12 @@ namespace fallout {
 #define INTERFACE_ITEM_ACTION_BUTTON_WIDTH 188
 #define INTERFACE_ITEM_ACTION_BUTTON_HEIGHT 67
 
+// Action Points bar configuration
+#define AP_MAX_DISPLAY (gInterfaceBarSuperWide ? 16 : 10)
+#define AP_LIGHTS_SHIFT (gInterfaceBarSuperWide ? 3 : 0)
+#define AP_START_X (316 + gInterfaceBarContentOffset - AP_LIGHTS_SHIFT * 9 - (gInterfaceBarSuperWide ? 1 : 0))
+#define AP_BAR_WIDTH (AP_MAX_DISPLAY * 9)
+
 // The values of it's members are offsets to beginning of numbers in
 // numbers.frm.
 typedef enum InterfaceNumbersColor {
@@ -284,7 +290,7 @@ static unsigned char* gInterfaceWindowBuffer;
 // This buffer is initialized once and does not change throughout the game.
 //
 // 0x59D40C
-static unsigned char gInterfaceActionPointsBarBackground[90 * 5];
+static unsigned char* gInterfaceActionPointsBarBackground = nullptr;
 
 static FrmImage _inventoryButtonNormalFrmImage;
 static FrmImage _inventoryButtonPressedFrmImage;
@@ -669,6 +675,32 @@ int interfaceInit()
     if (!backgroundFrmImage.lock(backgroundFid)) {
         return intface_fatal_error(-1);
     }
+
+    if (gInterfaceBarSuperWide) {
+        gInterfaceActionPointsBarBackground = (unsigned char*)internal_malloc(AP_BAR_WIDTH * 5);
+        if (gInterfaceActionPointsBarBackground) {
+            // Get the background for the lights from the main background.
+            unsigned char* src = backgroundFrmImage.getData() + 14 * backgroundFrmImage.getWidth() + AP_START_X;
+            for (int row = 0; row < 5; row++) {
+                memcpy(gInterfaceActionPointsBarBackground + row * AP_BAR_WIDTH, src, AP_BAR_WIDTH);
+                src += backgroundFrmImage.getWidth();
+            }
+        }
+    } else {
+        // Old 10-light layout (no 1pix shift...?)
+        gInterfaceActionPointsBarBackground = (unsigned char*)internal_malloc(90 * 5);
+        unsigned char* src = backgroundFrmImage.getData() + 14 * backgroundFrmImage.getWidth() + 316;
+        for (int row = 0; row < 5; row++) {
+            memcpy(gInterfaceActionPointsBarBackground + row * 90, src, 90);
+            src += backgroundFrmImage.getWidth();
+        }
+    }
+
+    // Update the action points bar rect
+    gInterfaceBarActionPointsBarRect.left = AP_START_X;
+    gInterfaceBarActionPointsBarRect.right = AP_START_X + AP_BAR_WIDTH - 1;
+    gInterfaceBarActionPointsBarRect.top = 14;
+    gInterfaceBarActionPointsBarRect.bottom = 19;
 
     blitBufferToBuffer(backgroundFrmImage.getData(),
         backgroundFrmImage.getWidth(),
@@ -1075,7 +1107,6 @@ void interfaceFree()
         backgroundFrmImage.unlock();
         gMultidexMapBgFrmImage.unlock();
         gMultidexSkilldexBgFrmImage.unlock();
-
         gBigNumbersFrmImage.unlock();
 
         // Destroy any remaining skilldex buttons
@@ -1091,6 +1122,10 @@ void interfaceFree()
         if (gInterfaceBarWindow != -1) {
             windowDestroy(gInterfaceBarWindow);
             gInterfaceBarWindow = -1;
+        }
+        if (gInterfaceActionPointsBarBackground) {
+            internal_free(gInterfaceActionPointsBarBackground);
+            gInterfaceActionPointsBarBackground = nullptr;
         }
     }
 
@@ -1391,11 +1426,15 @@ void interfaceRenderActionPoints(int actionPointsLeft, int bonusActionPoints)
         return;
     }
 
-    blitBufferToBuffer(gInterfaceActionPointsBarBackground, 90, 5, 90, gInterfaceWindowBuffer + 14 * gInterfaceBarWidth + gInterfaceBarContentOffset + 316, gInterfaceBarWidth);
+    // Restore background directly from the main background FRM
+    blitBufferToBuffer(backgroundFrmImage.getData() + 14 * backgroundFrmImage.getWidth() + AP_START_X,
+                       AP_BAR_WIDTH, 5, backgroundFrmImage.getWidth(),
+                       gInterfaceWindowBuffer + 14 * gInterfaceBarWidth + AP_START_X,
+                       gInterfaceBarWidth);
 
     if (actionPointsLeft == -1) {
         frmData = _redLightFrmImage.getData();
-        actionPointsLeft = 10;
+        actionPointsLeft = AP_MAX_DISPLAY;
         bonusActionPoints = 0;
     } else {
         frmData = _greenLightFrmImage.getData();
@@ -1403,14 +1442,13 @@ void interfaceRenderActionPoints(int actionPointsLeft, int bonusActionPoints)
         if (actionPointsLeft < 0) {
             actionPointsLeft = 0;
         }
-
-        if (actionPointsLeft > 10) {
-            actionPointsLeft = 10;
+        if (actionPointsLeft > AP_MAX_DISPLAY) {
+            actionPointsLeft = AP_MAX_DISPLAY;
         }
 
         if (bonusActionPoints >= 0) {
-            if (actionPointsLeft + bonusActionPoints > 10) {
-                bonusActionPoints = 10 - actionPointsLeft;
+            if (actionPointsLeft + bonusActionPoints > AP_MAX_DISPLAY) {
+                bonusActionPoints = AP_MAX_DISPLAY - actionPointsLeft;
             }
         } else {
             bonusActionPoints = 0;
@@ -1419,15 +1457,23 @@ void interfaceRenderActionPoints(int actionPointsLeft, int bonusActionPoints)
 
     int index;
     for (index = 0; index < actionPointsLeft; index++) {
-        blitBufferToBuffer(frmData, 5, 5, 5, gInterfaceWindowBuffer + 14 * gInterfaceBarWidth + 316 + index * 9 + gInterfaceBarContentOffset, gInterfaceBarWidth);
+        int lightX = AP_START_X + index * 9;
+        blitBufferToBufferTrans(frmData, 5, 5, 5,
+            gInterfaceWindowBuffer + 14 * gInterfaceBarWidth + lightX,
+            gInterfaceBarWidth);
     }
 
+    unsigned char* yellowData = _yellowLightFrmImage.getData();
     for (; index < (actionPointsLeft + bonusActionPoints); index++) {
-        blitBufferToBuffer(_yellowLightFrmImage.getData(), 5, 5, 5, gInterfaceWindowBuffer + 14 * gInterfaceBarWidth + 316 + gInterfaceBarContentOffset + index * 9, gInterfaceBarWidth);
+        int lightX = AP_START_X + index * 9;
+        blitBufferToBufferTrans(yellowData, 5, 5, 5,
+            gInterfaceWindowBuffer + 14 * gInterfaceBarWidth + lightX,
+            gInterfaceBarWidth);
     }
 
     if (!gInterfaceBarInitialized) {
-        windowRefreshRect(gInterfaceBarWindow, &gInterfaceBarActionPointsBarRect);
+        Rect rect = { AP_START_X, 14, AP_START_X + AP_BAR_WIDTH - 1, 19 };
+        windowRefreshRect(gInterfaceBarWindow, &rect);
     }
 }
 

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -2436,15 +2436,48 @@ static void interfaceUpdateAmmoBar(int x, int ratio)
 // Discrete ammo bar with uniform block sizes, gaps, and bottom-up consumption.
 static void enhancedInterfaceUpdateAmmoBar(int x, int ratio)
 {
-    (void)ratio;
+    (void)ratio; // ratio is not used directly; recompute from the item.
 
     if (gInterfaceBarWindow == -1) return;
 
     InterfaceItemState* itemState = &gInterfaceItemStates[gInterfaceCurrentHand];
-    Object* weapon = itemState->item;
+    Object* item = itemState->item;
 
-    // No weapon -> clear bar
-    if (!weapon || itemGetType(weapon) != ITEM_TYPE_WEAPON) {
+    int maxUnits = 0;
+    int currentUnits = 0;
+
+    if (item != nullptr) {
+        int itemType = itemGetType(item);
+
+        if (itemState->isWeapon != 0) {
+            int maxAmmo = ammoGetCapacity(item);
+            int currentAmmo = ammoGetQuantity(item);
+            if (maxAmmo > 0) {
+                // Determine burst size
+                int hitMode;
+                bool aiming;
+                if (interfaceGetCurrentHitMode(&hitMode, &aiming) != 0) {
+                    hitMode = itemState->primaryHitMode;
+                }
+                int anim = critterGetAnimationForHitMode(gDude, hitMode);
+                bool isBurst = (anim == ANIM_FIRE_BURST || anim == ANIM_FIRE_CONTINUOUS);
+                int burstSize = isBurst ? weaponGetBurstRounds(item) : 1;
+
+                maxUnits = maxAmmo / burstSize;
+                currentUnits = currentAmmo / burstSize;
+            }
+        } else if (itemType == ITEM_TYPE_MISC) {
+            int maxCharges = miscItemGetMaxCharges(item);
+            int currentCharges = miscItemGetCharges(item);
+            if (maxCharges > 0) {
+                maxUnits = maxCharges;
+                currentUnits = currentCharges;
+            }
+        }
+    }
+
+    if (maxUnits <= 0) {
+        // Clear the bar - no ammo/charges to display.
         unsigned char* dest = gInterfaceWindowBuffer + gInterfaceBarWidth * 26 + x;
         unsigned char* bgSrc = backgroundFrmImage.getData() + 26 * backgroundFrmImage.getWidth() + x;
         for (int row = 0; row < 70; row++) {
@@ -2457,57 +2490,36 @@ static void enhancedInterfaceUpdateAmmoBar(int x, int ratio)
         return;
     }
 
-    int maxAmmo = ammoGetCapacity(weapon);
-    int currentAmmo = ammoGetQuantity(weapon);
-    if (maxAmmo <= 0) return;
+    if (currentUnits > maxUnits) currentUnits = maxUnits;
 
-    int hitMode;
-    bool aiming;
-    if (interfaceGetCurrentHitMode(&hitMode, &aiming) != 0) {
-        hitMode = itemState->primaryHitMode;
-    }
-    int anim = critterGetAnimationForHitMode(gDude, hitMode);
-    bool isBurst = (anim == ANIM_FIRE_BURST || anim == ANIM_FIRE_CONTINUOUS);
-    int burstSize = isBurst ? weaponGetBurstRounds(weapon) : 1;
-
-    int maxUnits = maxAmmo / burstSize;
-    int currentUnits = currentAmmo / burstSize;
-
-    int displayMax;
-    int displayCurrent;
+    // Determine gap and block size based on maxUnits.
     int gap;
     int blockSize;
     bool dotted;
 
+    // Main style - 3 pixel gap (fallback to 2)
     if (maxUnits <= 24) {
-        // Dotted 'round' blocks, fills the bar, uses 3px gaps (fallback to 2)
-        displayMax = maxUnits;
-        displayCurrent = currentUnits;
         gap = 3;
-        blockSize = (70 - gap * (displayMax - 1)) / displayMax;
+        blockSize = (70 - gap * (maxUnits - 1)) / maxUnits;
         if (blockSize < 1) {
             gap = 2;
-            blockSize = (70 - gap * (displayMax - 1)) / displayMax;
+            blockSize = (70 - gap * (maxUnits - 1)) / maxUnits;
             if (blockSize < 1) blockSize = 1;
         }
         dotted = true;
-    } else if (maxUnits <= 35) {
-        // Secondary fallback - exactly 1 pixel = 1 round, gap=1, no stretching
-        displayMax = maxUnits;
-        displayCurrent = currentUnits;
-        gap = 1;
-        blockSize = 1;
-        dotted = false;
+    // Second fallback - gap of 1, 'round' of 1
     } else {
-        // Overflow: cap at 35 blocks - any weapons more than 35 rounds?
-        displayMax = 35;
-        displayCurrent = (currentUnits > 35) ? 35 : currentUnits;
         gap = 1;
         blockSize = 1;
         dotted = false;
+        if (maxUnits > 35) {
+            // We'll cap maxUnits to 35 and scale currentUnits - any weapon/item more than 35 rounds?
+            int oldMax = maxUnits;
+            maxUnits = 35;
+            currentUnits = (currentUnits * maxUnits + oldMax - 1) / oldMax;
+            if (currentUnits > maxUnits) currentUnits = maxUnits;
+        }
     }
-
-    if (displayMax == 0) return;
 
     unsigned char* dest = gInterfaceWindowBuffer + gInterfaceBarWidth * 26 + x;
     unsigned char* bgSrc = backgroundFrmImage.getData() + 26 * backgroundFrmImage.getWidth() + x;
@@ -2518,13 +2530,8 @@ static void enhancedInterfaceUpdateAmmoBar(int x, int ratio)
     }
 
     // Draw blocks from bottom (row 69) upward.
-    for (int i = 0; i < displayMax; i++) {
-        // Lit if this block is among the bottom `displayCurrent` blocks.
-        bool lit = (i < displayCurrent);
-
-        // Calculate the starting row for this block (absolute, 0 = top).
-        // Block 0 starts at row 69 - blockSize + 1.
-        // Block 1 starts at row 69 - blockSize - gap - blockSize + 1, etc.
+    for (int i = 0; i < maxUnits; i++) {
+        bool lit = (i < currentUnits);
         int startRow = 69 - (i * (blockSize + gap)) - blockSize + 1;
         if (startRow < 0) break;
 
@@ -2532,9 +2539,8 @@ static void enhancedInterfaceUpdateAmmoBar(int x, int ratio)
             int row = startRow + r;
             if (row < 0 || row >= 70) continue;
             if (lit) {
-                // In dotted mode (normal), skip odd rows to let the background show.
                 if (dotted && (r % 2 == 1)) {
-                    continue;
+                    continue; // skip odd rows to let background show
                 }
                 dest[row * gInterfaceBarWidth] = 196; // green
             }

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -61,7 +61,7 @@ namespace fallout {
 // Action Points bar configuration
 #define AP_MAX_DISPLAY (gInterfaceBarSuperWide ? 16 : 10)
 #define AP_LIGHTS_SHIFT (gInterfaceBarSuperWide ? 3 : 0)
-#define AP_START_X (316 + gInterfaceBarContentOffset - AP_LIGHTS_SHIFT * 9 - (gInterfaceBarSuperWide ? 1 : 0))
+#define AP_START_X (316 + gInterfaceBarContentOffset - AP_LIGHTS_SHIFT * 9)
 #define AP_BAR_WIDTH (AP_MAX_DISPLAY * 9)
 
 // The values of it's members are offsets to beginning of numbers in

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -116,6 +116,7 @@ static int endTurnButtonFree();
 static int endCombatButtonInit();
 static int endCombatButtonFree();
 static void interfaceUpdateAmmoBar(int x, int ratio);
+static void enhancedInterfaceUpdateAmmoBar(int x, int ratio);
 static int _intface_item_reload();
 static void interfaceDrawActionButtonOverlay(unsigned char* data, int width, int height, int pitch, int upX, int upY, int darkenColor);
 static void interfaceRenderCounterAnimationStep(unsigned char* src, unsigned char* dest, int delay, Rect* numbersRect, bool refreshMouse);
@@ -1789,7 +1790,11 @@ int _intface_update_ammo_lights()
         }
     }
 
-    interfaceUpdateAmmoBar(463 + gInterfaceBarContentOffset, ratio);
+    if (settings.enhancements.strict_vanilla){
+        interfaceUpdateAmmoBar(463 + gInterfaceBarContentOffset, ratio);
+    } else {
+        enhancedInterfaceUpdateAmmoBar(463 + gInterfaceBarContentOffset, ratio);
+    }
 
     return 0;
 }
@@ -2424,6 +2429,121 @@ static void interfaceUpdateAmmoBar(int x, int ratio)
         rect.top = 26;
         rect.right = x + 1;
         rect.bottom = 26 + 70;
+        windowRefreshRect(gInterfaceBarWindow, &rect);
+    }
+}
+
+// Discrete ammo bar with uniform block sizes, gaps, and bottom-up consumption.
+static void enhancedInterfaceUpdateAmmoBar(int x, int ratio)
+{
+    (void)ratio;
+
+    if (gInterfaceBarWindow == -1) return;
+
+    InterfaceItemState* itemState = &gInterfaceItemStates[gInterfaceCurrentHand];
+    Object* weapon = itemState->item;
+
+    // No weapon -> clear bar
+    if (!weapon || itemGetType(weapon) != ITEM_TYPE_WEAPON) {
+        unsigned char* dest = gInterfaceWindowBuffer + gInterfaceBarWidth * 26 + x;
+        unsigned char* bgSrc = backgroundFrmImage.getData() + 26 * backgroundFrmImage.getWidth() + x;
+        for (int row = 0; row < 70; row++) {
+            dest[row * gInterfaceBarWidth] = bgSrc[row * backgroundFrmImage.getWidth()];
+        }
+        if (!gInterfaceBarInitialized) {
+            Rect rect = { x, 26, x + 1, 26 + 70 - 1 };
+            windowRefreshRect(gInterfaceBarWindow, &rect);
+        }
+        return;
+    }
+
+    int maxAmmo = ammoGetCapacity(weapon);
+    int currentAmmo = ammoGetQuantity(weapon);
+    if (maxAmmo <= 0) return;
+
+    int hitMode;
+    bool aiming;
+    if (interfaceGetCurrentHitMode(&hitMode, &aiming) != 0) {
+        hitMode = itemState->primaryHitMode;
+    }
+    int anim = critterGetAnimationForHitMode(gDude, hitMode);
+    bool isBurst = (anim == ANIM_FIRE_BURST || anim == ANIM_FIRE_CONTINUOUS);
+    int burstSize = isBurst ? weaponGetBurstRounds(weapon) : 1;
+
+    int maxUnits = maxAmmo / burstSize;
+    int currentUnits = currentAmmo / burstSize;
+
+    int displayMax;
+    int displayCurrent;
+    int gap;
+    int blockSize;
+    bool dotted;
+
+    if (maxUnits <= 24) {
+        // Dotted 'round' blocks, fills the bar, uses 3px gaps (fallback to 2)
+        displayMax = maxUnits;
+        displayCurrent = currentUnits;
+        gap = 3;
+        blockSize = (70 - gap * (displayMax - 1)) / displayMax;
+        if (blockSize < 1) {
+            gap = 2;
+            blockSize = (70 - gap * (displayMax - 1)) / displayMax;
+            if (blockSize < 1) blockSize = 1;
+        }
+        dotted = true;
+    } else if (maxUnits <= 35) {
+        // Secondary fallback - exactly 1 pixel = 1 round, gap=1, no stretching
+        displayMax = maxUnits;
+        displayCurrent = currentUnits;
+        gap = 1;
+        blockSize = 1;
+        dotted = false;
+    } else {
+        // Overflow: cap at 35 blocks - any weapons more than 35 rounds?
+        displayMax = 35;
+        displayCurrent = (currentUnits > 35) ? 35 : currentUnits;
+        gap = 1;
+        blockSize = 1;
+        dotted = false;
+    }
+
+    if (displayMax == 0) return;
+
+    unsigned char* dest = gInterfaceWindowBuffer + gInterfaceBarWidth * 26 + x;
+    unsigned char* bgSrc = backgroundFrmImage.getData() + 26 * backgroundFrmImage.getWidth() + x;
+
+    // Restore background
+    for (int row = 0; row < 70; row++) {
+        dest[row * gInterfaceBarWidth] = bgSrc[row * backgroundFrmImage.getWidth()];
+    }
+
+    // Draw blocks from bottom (row 69) upward.
+    for (int i = 0; i < displayMax; i++) {
+        // Lit if this block is among the bottom `displayCurrent` blocks.
+        bool lit = (i < displayCurrent);
+
+        // Calculate the starting row for this block (absolute, 0 = top).
+        // Block 0 starts at row 69 - blockSize + 1.
+        // Block 1 starts at row 69 - blockSize - gap - blockSize + 1, etc.
+        int startRow = 69 - (i * (blockSize + gap)) - blockSize + 1;
+        if (startRow < 0) break;
+
+        for (int r = 0; r < blockSize; r++) {
+            int row = startRow + r;
+            if (row < 0 || row >= 70) continue;
+            if (lit) {
+                // In dotted mode (normal), skip odd rows to let the background show.
+                if (dotted && (r % 2 == 1)) {
+                    continue;
+                }
+                dest[row * gInterfaceBarWidth] = 196; // green
+            }
+        }
+    }
+
+    // Refresh the column
+    if (!gInterfaceBarInitialized) {
+        Rect rect = { x, 26, x + 1, 26 + 70 - 1 };
         windowRefreshRect(gInterfaceBarWindow, &rect);
     }
 }

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -1428,9 +1428,9 @@ void interfaceRenderActionPoints(int actionPointsLeft, int bonusActionPoints)
 
     // Restore background directly from the main background FRM
     blitBufferToBuffer(backgroundFrmImage.getData() + 14 * backgroundFrmImage.getWidth() + AP_START_X,
-                       AP_BAR_WIDTH, 5, backgroundFrmImage.getWidth(),
-                       gInterfaceWindowBuffer + 14 * gInterfaceBarWidth + AP_START_X,
-                       gInterfaceBarWidth);
+        AP_BAR_WIDTH, 5, backgroundFrmImage.getWidth(),
+        gInterfaceWindowBuffer + 14 * gInterfaceBarWidth + AP_START_X,
+        gInterfaceBarWidth);
 
     if (actionPointsLeft == -1) {
         frmData = _redLightFrmImage.getData();
@@ -1836,7 +1836,7 @@ int _intface_update_ammo_lights()
         }
     }
 
-    if (settings.enhancements.strict_vanilla){
+    if (settings.enhancements.strict_vanilla) {
         interfaceUpdateAmmoBar(463 + gInterfaceBarContentOffset, ratio);
     } else {
         enhancedInterfaceUpdateAmmoBar(463 + gInterfaceBarContentOffset, ratio);
@@ -2553,7 +2553,7 @@ static void enhancedInterfaceUpdateAmmoBar(int x, int ratio)
             if (blockSize < 1) blockSize = 1;
         }
         dotted = true;
-    // Second fallback - gap of 1, 'round' of 1
+        // Second fallback - gap of 1, 'round' of 1
     } else {
         gap = 1;
         blockSize = 1;


### PR DESCRIPTION
### Description

- enhanced action point bar for superwide mode
- enhanced ammo-meter for gated by strict-vanilla mode

Action point bar now has 16 lights
Also fixed a 1-pixel error in the vanilla game which offset the lights incorrectly.
Changed lights blitting to be transparent


Ammo-meter divides into discrete 'rounds' which are shown with a 3pixel gap (2pixel fallback - 1pixel 2nd fallback)
Shows clear difference between single and burst rounds
Updated interface with right shifted ammo, hp bars, and right side buttons - more space for the ammo-meter

### Screenshots
<img width="2424" height="1656" alt="Screenshot 2026-07-04 at 0 30 15" src="https://github.com/user-attachments/assets/e8cbebb5-7964-480e-a09b-a01a9572fccc" />

<img width="753" height="196" alt="Screenshot 2026-07-03 at 19 18 58" src="https://github.com/user-attachments/assets/baeb780f-477a-4a3e-b362-ecea2b36e001" />
<img width="756" height="195" alt="Screenshot 2026-07-03 at 19 18 33" src="https://github.com/user-attachments/assets/06182472-77c8-44bd-89b1-c6ecf37b3f69" />
<img width="762" height="196" alt="Screenshot 2026-07-03 at 19 18 23" src="https://github.com/user-attachments/assets/00397f90-d665-4b06-9531-afb2ca1767dd" />

