### PR TITLE
Add multidex skill selection for superwide UI

### DIFF
--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1449,38 +1449,27 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
                             break;
                         }
                         break;
-                    case GAME_MOUSE_ACTION_MENU_ITEM_USE_SKILL:
-                        if (1) {
+                        case GAME_MOUSE_ACTION_MENU_ITEM_USE_SKILL:
+                        {
                             int skill = -1;
-
-                            int rc = skilldexOpen();
-                            switch (rc) {
-                            case SKILLDEX_RC_SNEAK:
-                                _action_skill_use(SKILL_SNEAK);
-                                break;
-                            case SKILLDEX_RC_LOCKPICK:
-                                skill = SKILL_LOCKPICK;
-                                break;
-                            case SKILLDEX_RC_STEAL:
-                                skill = SKILL_STEAL;
-                                break;
-                            case SKILLDEX_RC_TRAPS:
-                                skill = SKILL_TRAPS;
-                                break;
-                            case SKILLDEX_RC_FIRST_AID:
-                                skill = SKILL_FIRST_AID;
-                                break;
-                            case SKILLDEX_RC_DOCTOR:
-                                skill = SKILL_DOCTOR;
-                                break;
-                            case SKILLDEX_RC_SCIENCE:
-                                skill = SKILL_SCIENCE;
-                                break;
-                            case SKILLDEX_RC_REPAIR:
-                                skill = SKILL_REPAIR;
-                                break;
+                            if (interfaceIsSuperWide()) {
+                                // use multidex in superwide mode
+                                skill = multidexSkillSelectExact();
+                            } else {
+                                // use regular skilldex otherwise
+                                int rc = skilldexOpen();
+                                switch (rc) {
+                                    case SKILLDEX_RC_SNEAK:      skill = SKILL_SNEAK;      break;
+                                    case SKILLDEX_RC_LOCKPICK:   skill = SKILL_LOCKPICK;   break;
+                                    case SKILLDEX_RC_STEAL:      skill = SKILL_STEAL;      break;
+                                    case SKILLDEX_RC_TRAPS:      skill = SKILL_TRAPS;      break;
+                                    case SKILLDEX_RC_FIRST_AID:  skill = SKILL_FIRST_AID;  break;
+                                    case SKILLDEX_RC_DOCTOR:     skill = SKILL_DOCTOR;     break;
+                                    case SKILLDEX_RC_SCIENCE:    skill = SKILL_SCIENCE;    break;
+                                    case SKILLDEX_RC_REPAIR:     skill = SKILL_REPAIR;     break;
+                                    default: skill = -1; break;
+                                }
                             }
-
                             if (skill != -1) {
                                 actionUseSkill(gDude, targetObj, skill);
                             }

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1459,7 +1459,7 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
                             int rc = skilldexOpen();
                             switch (rc) {
                             case SKILLDEX_RC_SNEAK:
-                                skill = SKILL_SNEAK;
+                                _action_skill_use(SKILL_SNEAK);
                                 break;
                             case SKILLDEX_RC_LOCKPICK:
                                 skill = SKILL_LOCKPICK;

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1449,32 +1449,48 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
                             break;
                         }
                         break;
-                        case GAME_MOUSE_ACTION_MENU_ITEM_USE_SKILL:
-                        {
-                            int skill = -1;
-                            if (interfaceIsSuperWide()) {
-                                // use multidex in superwide mode
-                                skill = multidexSkillSelectExact();
-                            } else {
-                                // use regular skilldex otherwise
-                                int rc = skilldexOpen();
-                                switch (rc) {
-                                    case SKILLDEX_RC_SNEAK:      skill = SKILL_SNEAK;      break;
-                                    case SKILLDEX_RC_LOCKPICK:   skill = SKILL_LOCKPICK;   break;
-                                    case SKILLDEX_RC_STEAL:      skill = SKILL_STEAL;      break;
-                                    case SKILLDEX_RC_TRAPS:      skill = SKILL_TRAPS;      break;
-                                    case SKILLDEX_RC_FIRST_AID:  skill = SKILL_FIRST_AID;  break;
-                                    case SKILLDEX_RC_DOCTOR:     skill = SKILL_DOCTOR;     break;
-                                    case SKILLDEX_RC_SCIENCE:    skill = SKILL_SCIENCE;    break;
-                                    case SKILLDEX_RC_REPAIR:     skill = SKILL_REPAIR;     break;
-                                    default: skill = -1; break;
-                                }
-                            }
-                            if (skill != -1) {
-                                actionUseSkill(gDude, targetObj, skill);
+                    case GAME_MOUSE_ACTION_MENU_ITEM_USE_SKILL: {
+                        int skill = -1;
+                        if (interfaceIsSuperWide()) {
+                            // use multidex in superwide mode
+                            skill = multidexSkillSelectExact();
+                        } else {
+                            // use regular skilldex otherwise
+                            int rc = skilldexOpen();
+                            switch (rc) {
+                            case SKILLDEX_RC_SNEAK:
+                                skill = SKILL_SNEAK;
+                                break;
+                            case SKILLDEX_RC_LOCKPICK:
+                                skill = SKILL_LOCKPICK;
+                                break;
+                            case SKILLDEX_RC_STEAL:
+                                skill = SKILL_STEAL;
+                                break;
+                            case SKILLDEX_RC_TRAPS:
+                                skill = SKILL_TRAPS;
+                                break;
+                            case SKILLDEX_RC_FIRST_AID:
+                                skill = SKILL_FIRST_AID;
+                                break;
+                            case SKILLDEX_RC_DOCTOR:
+                                skill = SKILL_DOCTOR;
+                                break;
+                            case SKILLDEX_RC_SCIENCE:
+                                skill = SKILL_SCIENCE;
+                                break;
+                            case SKILLDEX_RC_REPAIR:
+                                skill = SKILL_REPAIR;
+                                break;
+                            default:
+                                skill = -1;
+                                break;
                             }
                         }
-                        break;
+                        if (skill != -1) {
+                            actionUseSkill(gDude, targetObj, skill);
+                        }
+                    } break;
                     case GAME_MOUSE_ACTION_MENU_ITEM_PUSH:
                         actionPush(gDude, targetObj);
                         break;

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -352,6 +352,10 @@ static FrmImage gRedButtonDownFrmImage; // ID 7803
 static unsigned char* gMultidexInnardsBuffer = nullptr;
 static bool gMultidexAnimating = false;
 
+bool gMultidexSkillSelectActive = false;
+int  gMultidexSelectedSkill = -1;
+bool gMultidexSelectionDone = false;
+
 static int gInterfaceSidePanelsLeadingWindow = -1;
 static int gInterfaceSidePanelsTrailingWindow = -1;
 
@@ -3632,6 +3636,134 @@ static void multidexDestroySkillButtons(void)
     }
     gSkillButtonsCreated = false;
     memset(gSkillButtonSkill, 0, sizeof(gSkillButtonSkill));
+}
+
+static void multidexSkillSelectButtonPress(int btn, int event)
+{
+    int skill = gSkillButtonSkill[btn];
+    if (skill != -1) {
+        gMultidexSelectedSkill = skill;
+        gMultidexSelectionDone = true;
+        soundPlayFile("ib1p1xx1");
+    }
+}
+
+int multidexSkillSelectExact()
+{
+    if (!gInterfaceBarSuperWide || gInterfaceBarWindow == -1) {
+        return -1;
+    }
+
+    // Switch to skilldex panel if needed.
+    bool wasSkilldexMode = gMultidexSkilldexMode;
+    bool switched = false;
+    if (!wasSkilldexMode) {
+        multidexTogglePanel();
+        switched = true;
+    }
+
+    // Hide any custom mouse objects (action menu icons).
+    gameMouseObjectsHide();
+    // Set the cursor to the small arrow.
+    gameMouseSetCursor(MOUSE_CURSOR_ARROW);
+
+    // Disable iso so game world doesn't respond.
+    bool isoWasEnabled = isoDisable();
+
+    gameMouseSetCursor(MOUSE_CURSOR_ARROW);
+
+    // Get interface bar position.
+    Rect ifaceRect;
+    windowGetRect(gInterfaceBarWindow, &ifaceRect);
+
+    // Multidex skilldex area is 262x99 at (800,0) within interface bar.
+    int skillAreaX = ifaceRect.left + 800;
+    int skillAreaY = ifaceRect.top;
+    int skillAreaW = 262;
+    int skillAreaH = 99;
+
+    // Create a modal window covering exactly that area.
+    int modalWin = windowCreate(skillAreaX, skillAreaY, skillAreaW, skillAreaH,
+                                0, WINDOW_MODAL | WINDOW_TRANSPARENT | WINDOW_DONT_MOVE_TOP);
+    if (modalWin == -1) {
+        // Restore state on failure.
+        if (isoWasEnabled) isoEnable();
+        gameMouseObjectsShow();
+        if (switched) multidexTogglePanel();
+        return -1;
+    }
+
+    // Button layout (same as multidexCreateSkillButtons).
+    const int leftColX  = 15;
+    const int rightColX = 137;
+    const int startY    = 12;
+    const int spacingY  = 21;
+    const int btnW = gRedButtonUpFrmImage.getWidth();
+    const int btnH = gRedButtonUpFrmImage.getHeight();
+
+    // Create 8 skill buttons, key codes 501..508.
+    for (int i = 0; i < 8; i++) {
+        int x = (i < 4) ? leftColX : rightColX;
+        int y = startY + (i % 4) * spacingY;
+        int btn = buttonCreate(modalWin, x, y, btnW, btnH,
+                               -1, -1, -1, 501 + i,
+                               gRedButtonUpFrmImage.getData(),
+                               gRedButtonDownFrmImage.getData(),
+                               nullptr, BUTTON_FLAG_TRANSPARENT);
+        if (btn != -1) {
+            gSkillButtonSkill[btn] = gMultidexSkillIds[i];
+            buttonSetCallbacks(btn, multidexSkillSelectButtonPress, nullptr);
+        }
+    }
+
+    // Enter selection mode.
+    gMultidexSkillSelectActive = true;
+    gMultidexSelectedSkill = -1;
+    gMultidexSelectionDone = false;
+
+    // Modal loop (identical to skilldexOpen).
+    while (!gMultidexSelectionDone) {
+        sharedFpsLimiter.mark();
+
+        int keyCode = inputGetInput();
+        if (keyCode == KEY_ESCAPE || _game_user_wants_to_quit != 0) {
+            gMultidexSelectedSkill = -1;
+            gMultidexSelectionDone = true;
+            break;
+        }
+
+        // Right-click cancellation.
+        int mouseEvent = mouseGetEvent();
+        if (mouseEvent & MOUSE_EVENT_RIGHT_BUTTON_UP) {
+            gMultidexSelectedSkill = -1;
+            gMultidexSelectionDone = true;
+            break;
+        }
+
+        // Keep cursor as arrow (modal window prevents most changes, but just in case).
+        gameMouseSetCursor(MOUSE_CURSOR_ARROW);
+
+        renderPresent();
+        sharedFpsLimiter.throttle();
+    }
+
+    // Cleanup
+    windowDestroy(modalWin);
+    gMultidexSkillSelectActive = false;
+
+    // Restore iso and mouse
+    if (isoWasEnabled) isoEnable();
+    gameMouseObjectsShow();
+    gameMouseRefresh();
+
+    int selectedSkill = gMultidexSelectedSkill;
+
+    // Restore panel mode if switched.
+    if (switched) {
+        multidexTogglePanel();
+    }
+
+    return selectedSkill;
 }
 
 } // namespace fallout

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -353,7 +353,7 @@ static unsigned char* gMultidexInnardsBuffer = nullptr;
 static bool gMultidexAnimating = false;
 
 bool gMultidexSkillSelectActive = false;
-int  gMultidexSelectedSkill = -1;
+int gMultidexSelectedSkill = -1;
 bool gMultidexSelectionDone = false;
 
 static int gInterfaceSidePanelsLeadingWindow = -1;
@@ -3684,7 +3684,7 @@ int multidexSkillSelectExact()
 
     // Create a modal window covering exactly that area.
     int modalWin = windowCreate(skillAreaX, skillAreaY, skillAreaW, skillAreaH,
-                                0, WINDOW_MODAL | WINDOW_TRANSPARENT | WINDOW_DONT_MOVE_TOP);
+        0, WINDOW_MODAL | WINDOW_TRANSPARENT | WINDOW_DONT_MOVE_TOP);
     if (modalWin == -1) {
         // Restore state on failure.
         if (isoWasEnabled) isoEnable();
@@ -3694,10 +3694,10 @@ int multidexSkillSelectExact()
     }
 
     // Button layout (same as multidexCreateSkillButtons).
-    const int leftColX  = 15;
+    const int leftColX = 15;
     const int rightColX = 137;
-    const int startY    = 12;
-    const int spacingY  = 21;
+    const int startY = 12;
+    const int spacingY = 21;
     const int btnW = gRedButtonUpFrmImage.getWidth();
     const int btnH = gRedButtonUpFrmImage.getHeight();
 
@@ -3706,10 +3706,10 @@ int multidexSkillSelectExact()
         int x = (i < 4) ? leftColX : rightColX;
         int y = startY + (i % 4) * spacingY;
         int btn = buttonCreate(modalWin, x, y, btnW, btnH,
-                               -1, -1, -1, 501 + i,
-                               gRedButtonUpFrmImage.getData(),
-                               gRedButtonDownFrmImage.getData(),
-                               nullptr, BUTTON_FLAG_TRANSPARENT);
+            -1, -1, -1, 501 + i,
+            gRedButtonUpFrmImage.getData(),
+            gRedButtonDownFrmImage.getData(),
+            nullptr, BUTTON_FLAG_TRANSPARENT);
         if (btn != -1) {
             gSkillButtonSkill[btn] = gMultidexSkillIds[i];
             buttonSetCallbacks(btn, multidexSkillSelectButtonPress, nullptr);

--- a/src/interface.h
+++ b/src/interface.h
@@ -75,6 +75,7 @@ void multidexUpdateButtonStates(void);
 bool interfaceIsSuperWide(void);
 void multidexTogglePanel(void);
 void multidexRefreshSkilldexAnimated(const int oldValues[8]);
+int multidexSkillSelectExact();
 
 } // namespace fallout
 


### PR DESCRIPTION
### Description

Implement a modal multidex skill picker used when the interface is in superwide mode and the player chooses a skill from the action menu. game_mouse handling now calls multidexSkillSelectExact() when interfaceIsSuperWide(), falling back to the regular skilldex otherwise.

interface.cc: add globals to track selection state, a button press callback, and multidexSkillSelectExact() which creates a small modal window over the multidex area, populates skill buttons, runs a selection loop (handles Escape/right-click cancellation), and restores UI/iso/mouse state on exit. The skill selection result is returned to the caller. Also unify skill handling so selected skills are processed consistently.

interface.h: declare multidexSkillSelectExact().

This change enables proper skill selection in superwide layouts and centralizes modal selection logic.