### PR TITLE
Handle rest option events with correct indexing

### DIFF
--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -3725,10 +3725,10 @@ static void pipboyHandleAlarmClock(int eventCode)
             gPipboyTab = gPipboyPrevTab;
         }
     } else if (eventCode >= 1 && eventCode <= gPipboyRestOptionsCount) {
-        pipboyWindowRenderRestOptions(eventCode);          // highlight the clicked option (1?based)
-        int duration = eventCode - 1;                      // 0?based index into the duration list
+        pipboyWindowRenderRestOptions(eventCode); // highlight the clicked option (1?based)
+        int duration = eventCode - 1; // 0?based index into the duration list
         soundPlayFile("ib1p1xx1");
-            
+
         int minutes = 0;
         int hours = 0;
 

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -3725,8 +3725,8 @@ static void pipboyHandleAlarmClock(int eventCode)
             gPipboyTab = gPipboyPrevTab;
         }
     } else if (eventCode >= 1 && eventCode <= gPipboyRestOptionsCount) {
-        pipboyWindowRenderRestOptions(eventCode); // highlight the clicked option (1?based)
-        int duration = eventCode - 1; // 0?based index into the duration list
+        pipboyWindowRenderRestOptions(eventCode); // highlight the clicked option (1-based)
+        int duration = eventCode - 1; // 0-based index into the duration list
         soundPlayFile("ib1p1xx1");
 
         int minutes = 0;

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -3724,12 +3724,11 @@ static void pipboyHandleAlarmClock(int eventCode)
             // appropriate handler (not the alarm clock).
             gPipboyTab = gPipboyPrevTab;
         }
-    } else if (eventCode >= 4 && eventCode <= 17) {
+    } else if (eventCode >= 1 && eventCode <= gPipboyRestOptionsCount) {
+        pipboyWindowRenderRestOptions(eventCode);          // highlight the clicked option (1?based)
+        int duration = eventCode - 1;                      // 0?based index into the duration list
         soundPlayFile("ib1p1xx1");
-
-        pipboyWindowRenderRestOptions(eventCode - 3);
-
-        int duration = eventCode - 4;
+            
         int minutes = 0;
         int hours = 0;
 


### PR DESCRIPTION
- Replace hardcoded event range/offsets with gPipboyRestOptionsCount and 1-based indexing. pipboyWindowRenderRestOptions is now called with eventCode to highlight the clicked option, duration is computed as eventCode - 1, and soundPlayFile is moved accordingly. This makes rest option handling dynamic and fixes incorrect index offsets (removed the previous -3/-4 adjustments).

Fixes #135 
