### PR TITLE
Make tag/trait buttons checkable & fix toggles

### DIFF
--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1845,13 +1845,12 @@ static int characterEditorWindowInit()
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getWidth(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight(),
                 -1, -1,
-                eventCode,      // keyCode = eventCode
-                eventCode,      // eventCode = same value
+                eventCode, // keyCode = eventCode
+                eventCode, // eventCode = same value
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_OFF].getData(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getData(),
                 nullptr,
-                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE
-            );
+                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE);
             buttonSetCallbacks(gCharacterEditorTagSkillBtns[i], _gsound_red_butt_press, nullptr);
             y += _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight();
         }
@@ -1871,8 +1870,7 @@ static int characterEditorWindowInit()
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_OFF].getData(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getData(),
                 nullptr,
-                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE
-            );
+                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE);
             buttonSetCallbacks(gCharacterEditorOptionalTraitBtns[i], _gsound_red_butt_press, nullptr);
             y += _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight() + OPTIONAL_TRAITS_BTN_SPACE;
         }
@@ -1892,8 +1890,7 @@ static int characterEditorWindowInit()
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_OFF].getData(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getData(),
                 nullptr,
-                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE
-            );
+                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE);
             buttonSetCallbacks(gCharacterEditorOptionalTraitBtns[i], _gsound_red_butt_press, nullptr);
             y += _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight() + OPTIONAL_TRAITS_BTN_SPACE;
         }
@@ -5761,13 +5758,10 @@ static void characterEditorHandleAdjustSkillButtonPressed(int keyCode)
 // 0x43B67C
 static void characterEditorToggleTaggedSkill(int skill)
 {
-    static int lastFailedSkill = -1;   // track which skill caused the popup
+    static int lastFailedSkill = -1; // track which skill caused the popup
 
     // Check if skill is already tagged
-    bool alreadyTagged = (skill == gCharacterEditorTempTaggedSkills[0] ||
-                          skill == gCharacterEditorTempTaggedSkills[1] ||
-                          skill == gCharacterEditorTempTaggedSkills[2] ||
-                          skill == gCharacterEditorTempTaggedSkills[3]);
+    bool alreadyTagged = (skill == gCharacterEditorTempTaggedSkills[0] || skill == gCharacterEditorTempTaggedSkills[1] || skill == gCharacterEditorTempTaggedSkills[2] || skill == gCharacterEditorTempTaggedSkills[3]);
 
     if (alreadyTagged) {
         // Remove the skill (successful toggle)
@@ -5781,7 +5775,7 @@ static void characterEditorToggleTaggedSkill(int skill)
         } else {
             gCharacterEditorTempTaggedSkills[2] = -1;
         }
-        lastFailedSkill = -1;   // success, clear the guard
+        lastFailedSkill = -1; // success, clear the guard
     } else {
         // Try to add the skill
         int count = 0;
@@ -5796,7 +5790,7 @@ static void characterEditorToggleTaggedSkill(int skill)
                     break;
                 }
             }
-            lastFailedSkill = -1;   // success, clear the guard
+            lastFailedSkill = -1; // success, clear the guard
         } else {
             // Too many – show popup only if this is a different skill
             if (skill != lastFailedSkill) {
@@ -5807,7 +5801,7 @@ static void characterEditorToggleTaggedSkill(int skill)
                 strcpy(line2, getmsg(&gCharacterEditorMessageList, &gCharacterEditorMessageListItem, 141));
                 const char* lines[] = { line2 };
                 showDialogBox(line1, lines, 1, 192, 126, _colorTable[COL_ORANGE], nullptr, _colorTable[COL_ORANGE], 0);
-                lastFailedSkill = skill;   // remember which skill caused the popup
+                lastFailedSkill = skill; // remember which skill caused the popup
             }
             // Fall through – sync loop will revert the button
         }
@@ -5822,10 +5816,7 @@ static void characterEditorToggleTaggedSkill(int skill)
 
     // Sync all buttons (alwauys run)
     for (int idx = 0; idx < SKILL_COUNT; idx++) {
-        int isTagged = (idx == gCharacterEditorTempTaggedSkills[0] ||
-                        idx == gCharacterEditorTempTaggedSkills[1] ||
-                        idx == gCharacterEditorTempTaggedSkills[2] ||
-                        idx == gCharacterEditorTempTaggedSkills[3]);
+        int isTagged = (idx == gCharacterEditorTempTaggedSkills[0] || idx == gCharacterEditorTempTaggedSkills[1] || idx == gCharacterEditorTempTaggedSkills[2] || idx == gCharacterEditorTempTaggedSkills[3]);
         _win_set_button_rest_state(gCharacterEditorTagSkillBtns[idx], isTagged ? 1 : 0, 1);
     }
 
@@ -5938,8 +5929,7 @@ static void characterEditorToggleOptionalTrait(int trait)
     static int lastFailedTrait = -1;
 
     // Check if trait is already selected
-    bool alreadySelected = (trait == gCharacterEditorTempTraits[0] ||
-                            trait == gCharacterEditorTempTraits[1]);
+    bool alreadySelected = (trait == gCharacterEditorTempTraits[0] || trait == gCharacterEditorTempTraits[1]);
 
     if (alreadySelected) {
         // Remove the trait (successful toggle)

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -5761,10 +5761,7 @@ static void characterEditorToggleTaggedSkill(int skill)
     static int lastFailedSkill = -1; // track which skill caused the popup
 
     // Check if skill is already tagged
-    bool alreadyTagged = (skill == gCharacterEditorTempTaggedSkills[0] ||
-                          skill == gCharacterEditorTempTaggedSkills[1] ||
-                          skill == gCharacterEditorTempTaggedSkills[2] ||
-                          skill == gCharacterEditorTempTaggedSkills[3]);
+    bool alreadyTagged = (skill == gCharacterEditorTempTaggedSkills[0] || skill == gCharacterEditorTempTaggedSkills[1] || skill == gCharacterEditorTempTaggedSkills[2] || skill == gCharacterEditorTempTaggedSkills[3]);
 
     if (alreadyTagged) {
         // Remove the skill (successful toggle)
@@ -5824,10 +5821,7 @@ static void characterEditorToggleTaggedSkill(int skill)
 
     // Sync all buttons (always run)
     for (int idx = 0; idx < SKILL_COUNT; idx++) {
-        int isTagged = (idx == gCharacterEditorTempTaggedSkills[0] ||
-                        idx == gCharacterEditorTempTaggedSkills[1] ||
-                        idx == gCharacterEditorTempTaggedSkills[2] ||
-                        idx == gCharacterEditorTempTaggedSkills[3]);
+        int isTagged = (idx == gCharacterEditorTempTaggedSkills[0] || idx == gCharacterEditorTempTaggedSkills[1] || idx == gCharacterEditorTempTaggedSkills[2] || idx == gCharacterEditorTempTaggedSkills[3]);
         _win_set_button_rest_state(gCharacterEditorTagSkillBtns[idx], isTagged ? 1 : 0, 1);
     }
 

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1890,6 +1890,9 @@ static int characterEditorWindowInit()
                 BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE);
             buttonSetCallbacks(gCharacterEditorOptionalTraitBtns[i], _gsound_red_butt_press, nullptr);
             y += _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight() + OPTIONAL_TRAITS_BTN_SPACE;
+            if (i == TRAIT_COUNT / 2 - 3) {
+                y += 2; // lowers bottom 2 traits 2-pixel
+            }
         }
 
         y = gOffsets.optionalTraitsButtonY;
@@ -1910,6 +1913,9 @@ static int characterEditorWindowInit()
                 BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE);
             buttonSetCallbacks(gCharacterEditorOptionalTraitBtns[i], _gsound_red_butt_press, nullptr);
             y += _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight() + OPTIONAL_TRAITS_BTN_SPACE;
+            if (i == TRAIT_COUNT - 3) {
+                y += 2; // lowers bottom 2 traits 2-pixels
+            }
         }
 
         characterEditorDrawOptionalTraits();

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1835,59 +1835,66 @@ static int characterEditorWindowInit()
         }
 
         y = gOffsets.tagSkillsButtonY;
+        // Tag Skills
         for (i = 0; i < SKILL_COUNT; i++) {
+            int eventCode = TAG_SKILLS_BUTTON_CODE + i; // 536..553
             gCharacterEditorTagSkillBtns[i] = buttonCreate(
                 gCharacterEditorWindow,
                 gOffsets.tagSkillsButtonX,
                 y,
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getWidth(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight(),
-                -1,
-                -1,
-                -1,
-                TAG_SKILLS_BUTTON_CODE + i,
+                -1, -1,
+                eventCode,      // keyCode = eventCode
+                eventCode,      // eventCode = same value
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_OFF].getData(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getData(),
                 nullptr,
-                32);
+                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE
+            );
+            buttonSetCallbacks(gCharacterEditorTagSkillBtns[i], _gsound_red_butt_press, nullptr);
             y += _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight();
         }
 
         y = gOffsets.optionalTraitsButtonY;
+        // Optional Traits (left column)
         for (i = 0; i < TRAIT_COUNT / 2; i++) {
+            int eventCode = OPTIONAL_TRAITS_BTN_CODE + i; // 555..562
             gCharacterEditorOptionalTraitBtns[i] = buttonCreate(
                 gCharacterEditorWindow,
                 gOffsets.optionalTraitsLeftButtonX,
                 y,
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getWidth(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight(),
-                -1,
-                -1,
-                -1,
-                OPTIONAL_TRAITS_BTN_CODE + i,
+                -1, -1, eventCode,
+                eventCode,
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_OFF].getData(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getData(),
                 nullptr,
-                32);
+                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE
+            );
+            buttonSetCallbacks(gCharacterEditorOptionalTraitBtns[i], _gsound_red_butt_press, nullptr);
             y += _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight() + OPTIONAL_TRAITS_BTN_SPACE;
         }
 
         y = gOffsets.optionalTraitsButtonY;
+        // Optional Traits (right column)
         for (i = TRAIT_COUNT / 2; i < TRAIT_COUNT; i++) {
+            int eventCode = OPTIONAL_TRAITS_BTN_CODE + i; // 563..570
             gCharacterEditorOptionalTraitBtns[i] = buttonCreate(
                 gCharacterEditorWindow,
                 gOffsets.optionalTraitsRightButtonX,
                 y,
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getWidth(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight(),
-                -1,
-                -1,
-                -1,
-                OPTIONAL_TRAITS_BTN_CODE + i,
+                -1, -1, eventCode,
+                eventCode,
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_OFF].getData(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getData(),
                 nullptr,
-                32);
+                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE
+            );
+            buttonSetCallbacks(gCharacterEditorOptionalTraitBtns[i], _gsound_red_butt_press, nullptr);
             y += _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight() + OPTIONAL_TRAITS_BTN_SPACE;
         }
 
@@ -5754,23 +5761,16 @@ static void characterEditorHandleAdjustSkillButtonPressed(int keyCode)
 // 0x43B67C
 static void characterEditorToggleTaggedSkill(int skill)
 {
-    int insertionIndex;
+    static int lastFailedSkill = -1;   // track which skill caused the popup
 
-    insertionIndex = 0;
-    for (int index = 3; index >= 0; index--) {
-        if (gCharacterEditorTempTaggedSkills[index] != -1) {
-            break;
-        }
-        insertionIndex++;
-    }
+    // Check if skill is already tagged
+    bool alreadyTagged = (skill == gCharacterEditorTempTaggedSkills[0] ||
+                          skill == gCharacterEditorTempTaggedSkills[1] ||
+                          skill == gCharacterEditorTempTaggedSkills[2] ||
+                          skill == gCharacterEditorTempTaggedSkills[3]);
 
-    if (gCharacterEditorIsCreationMode) {
-        insertionIndex -= 1;
-    }
-
-    gCharacterEditorOldTaggedSkillCount = insertionIndex;
-
-    if (skill == gCharacterEditorTempTaggedSkills[0] || skill == gCharacterEditorTempTaggedSkills[1] || skill == gCharacterEditorTempTaggedSkills[2] || skill == gCharacterEditorTempTaggedSkills[3]) {
+    if (alreadyTagged) {
+        // Remove the skill (successful toggle)
         if (skill == gCharacterEditorTempTaggedSkills[0]) {
             gCharacterEditorTempTaggedSkills[0] = gCharacterEditorTempTaggedSkills[1];
             gCharacterEditorTempTaggedSkills[1] = gCharacterEditorTempTaggedSkills[2];
@@ -5781,44 +5781,55 @@ static void characterEditorToggleTaggedSkill(int skill)
         } else {
             gCharacterEditorTempTaggedSkills[2] = -1;
         }
+        lastFailedSkill = -1;   // success, clear the guard
     } else {
-        if (gCharacterEditorTaggedSkillCount > 0) {
-            insertionIndex = 0;
-            for (int index = 0; index < 3; index++) {
-                if (gCharacterEditorTempTaggedSkills[index] == -1) {
+        // Try to add the skill
+        int count = 0;
+        for (int i = 0; i < 3; i++) {
+            if (gCharacterEditorTempTaggedSkills[i] != -1) count++;
+        }
+        if (count < 3) {
+            // Add skill (successful toggle)
+            for (int i = 0; i < 3; i++) {
+                if (gCharacterEditorTempTaggedSkills[i] == -1) {
+                    gCharacterEditorTempTaggedSkills[i] = skill;
                     break;
                 }
-                insertionIndex++;
             }
-            gCharacterEditorTempTaggedSkills[insertionIndex] = skill;
+            lastFailedSkill = -1;   // success, clear the guard
         } else {
-            soundPlayFile("iisxxxx1");
-
-            char line1[128];
-            strcpy(line1, getmsg(&gCharacterEditorMessageList, &gCharacterEditorMessageListItem, 140));
-
-            char line2[128];
-            strcpy(line2, getmsg(&gCharacterEditorMessageList, &gCharacterEditorMessageListItem, 141));
-
-            const char* lines[] = { line2 };
-            showDialogBox(line1, lines, 1, 192, 126, _colorTable[COL_ORANGE], nullptr, _colorTable[COL_ORANGE], 0);
+            // Too many – show popup only if this is a different skill
+            if (skill != lastFailedSkill) {
+                soundPlayFile("iisxxxx1");
+                char line1[128];
+                strcpy(line1, getmsg(&gCharacterEditorMessageList, &gCharacterEditorMessageListItem, 140));
+                char line2[128];
+                strcpy(line2, getmsg(&gCharacterEditorMessageList, &gCharacterEditorMessageListItem, 141));
+                const char* lines[] = { line2 };
+                showDialogBox(line1, lines, 1, 192, 126, _colorTable[COL_ORANGE], nullptr, _colorTable[COL_ORANGE], 0);
+                lastFailedSkill = skill;   // remember which skill caused the popup
+            }
+            // Fall through – sync loop will revert the button
         }
     }
 
-    insertionIndex = 0;
-    for (int index = 3; index >= 0; index--) {
-        if (gCharacterEditorTempTaggedSkills[index] != -1) {
-            break;
-        }
-        insertionIndex++;
+    // Recalculate count
+    int newCount = 0;
+    for (int i = 0; i < 3; i++) {
+        if (gCharacterEditorTempTaggedSkills[i] != -1) newCount++;
+    }
+    gCharacterEditorTaggedSkillCount = newCount;
+
+    // Sync all buttons (alwauys run)
+    for (int idx = 0; idx < SKILL_COUNT; idx++) {
+        int isTagged = (idx == gCharacterEditorTempTaggedSkills[0] ||
+                        idx == gCharacterEditorTempTaggedSkills[1] ||
+                        idx == gCharacterEditorTempTaggedSkills[2] ||
+                        idx == gCharacterEditorTempTaggedSkills[3]);
+        _win_set_button_rest_state(gCharacterEditorTagSkillBtns[idx], isTagged ? 1 : 0, 1);
     }
 
-    if (gCharacterEditorIsCreationMode) {
-        insertionIndex -= 1;
-    }
-
-    gCharacterEditorTaggedSkillCount = insertionIndex;
-
+    // Redraw
     characterEditorSelectedItem = skill + 61;
     characterEditorDrawPrimaryStat(RENDER_ALL_STATS, 0, 0);
     characterEditorDrawDerivedStats();
@@ -5924,55 +5935,72 @@ static void characterEditorDrawOptionalTraits()
 // 0x43BB0C
 static void characterEditorToggleOptionalTrait(int trait)
 {
-    if (trait == gCharacterEditorTempTraits[0] || trait == gCharacterEditorTempTraits[1]) {
+    static int lastFailedTrait = -1;
+
+    // Check if trait is already selected
+    bool alreadySelected = (trait == gCharacterEditorTempTraits[0] ||
+                            trait == gCharacterEditorTempTraits[1]);
+
+    if (alreadySelected) {
+        // Remove the trait (successful toggle)
         if (trait == gCharacterEditorTempTraits[0]) {
             gCharacterEditorTempTraits[0] = gCharacterEditorTempTraits[1];
             gCharacterEditorTempTraits[1] = -1;
         } else {
             gCharacterEditorTempTraits[1] = -1;
         }
+        lastFailedTrait = -1;
     } else {
-        if (gCharacterEditorTempTraitCount == 0) {
-            soundPlayFile("iisxxxx1");
-
-            char line1[128];
-            strcpy(line1, getmsg(&gCharacterEditorMessageList, &gCharacterEditorMessageListItem, 148));
-
-            char line2[128];
-            strcpy(line2, getmsg(&gCharacterEditorMessageList, &gCharacterEditorMessageListItem, 149));
-
-            const char* lines = { line2 };
-            showDialogBox(line1, &lines, 1, 192, 126, _colorTable[COL_ORANGE], nullptr, _colorTable[COL_ORANGE], 0);
-        } else {
-            for (int index = 0; index < 2; index++) {
-                if (gCharacterEditorTempTraits[index] == -1) {
-                    gCharacterEditorTempTraits[index] = trait;
+        // Try to add the trait
+        int count = 0;
+        for (int i = 0; i < 2; i++) {
+            if (gCharacterEditorTempTraits[i] != -1) count++;
+        }
+        if (count < 2) {
+            // Add trait (successful toggle)
+            for (int i = 0; i < 2; i++) {
+                if (gCharacterEditorTempTraits[i] == -1) {
+                    gCharacterEditorTempTraits[i] = trait;
                     break;
                 }
             }
+            lastFailedTrait = -1;
+        } else {
+            // Too many – show popup only if this is a different trait
+            if (trait != lastFailedTrait) {
+                soundPlayFile("iisxxxx1");
+                char line1[128];
+                strcpy(line1, getmsg(&gCharacterEditorMessageList, &gCharacterEditorMessageListItem, 148));
+                char line2[128];
+                strcpy(line2, getmsg(&gCharacterEditorMessageList, &gCharacterEditorMessageListItem, 149));
+                const char* lines[] = { line2 };
+                showDialogBox(line1, lines, 1, 192, 126, _colorTable[COL_ORANGE], nullptr, _colorTable[COL_ORANGE], 0);
+                lastFailedTrait = trait;
+            }
+            // Fall through – sync loop will revert the button
         }
     }
 
-    gCharacterEditorTempTraitCount = 0;
-    for (int index = 1; index != 0; index--) {
-        if (gCharacterEditorTempTraits[index] != -1) {
-            break;
-        }
-        gCharacterEditorTempTraitCount++;
+    // Recalculate count
+    int newCount = 0;
+    for (int i = 0; i < 2; i++) {
+        if (gCharacterEditorTempTraits[i] != -1) newCount++;
+    }
+    gCharacterEditorTempTraitCount = newCount;
+
+    // Sync all buttons (always run)
+    for (int idx = 0; idx < TRAIT_COUNT; idx++) {
+        int isSelected = (idx == gCharacterEditorTempTraits[0] || idx == gCharacterEditorTempTraits[1]);
+        _win_set_button_rest_state(gCharacterEditorOptionalTraitBtns[idx], isSelected ? 1 : 0, 1);
     }
 
+    // Redraw
     characterEditorSelectedItem = trait + EDITOR_FIRST_TRAIT;
-
     characterEditorDrawOptionalTraits();
     characterEditorDrawSkills(0);
     critterUpdateDerivedStats(gDude);
-    // Use offsets for character points value position
-    characterEditorDrawBigNumber(gOffsets.charPointsAdjustX,
-        gOffsets.charPointsAdjustY,
-        0,
-        gCharacterEditorRemainingCharacterPoints,
-        0,
-        gCharacterEditorWindow);
+    characterEditorDrawBigNumber(gOffsets.charPointsAdjustX, gOffsets.charPointsAdjustY, 0,
+        gCharacterEditorRemainingCharacterPoints, 0, gCharacterEditorWindow);
     characterEditorDrawPrimaryStat(RENDER_ALL_STATS, false, 0);
     characterEditorDrawDerivedStats();
     characterEditorDrawCard();

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -921,10 +921,7 @@ static void characterEditorSyncButtonStates()
 
     // Tag Skills
     for (int idx = 0; idx < SKILL_COUNT; idx++) {
-        int isTagged = (idx == gCharacterEditorTempTaggedSkills[0] ||
-                        idx == gCharacterEditorTempTaggedSkills[1] ||
-                        idx == gCharacterEditorTempTaggedSkills[2] ||
-                        idx == gCharacterEditorTempTaggedSkills[3]);
+        int isTagged = (idx == gCharacterEditorTempTaggedSkills[0] || idx == gCharacterEditorTempTaggedSkills[1] || idx == gCharacterEditorTempTaggedSkills[2] || idx == gCharacterEditorTempTaggedSkills[3]);
         _win_set_button_rest_state(gCharacterEditorTagSkillBtns[idx], isTagged ? 1 : 0, 0); // flags=0: no event
     }
 

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -5761,7 +5761,10 @@ static void characterEditorToggleTaggedSkill(int skill)
     static int lastFailedSkill = -1; // track which skill caused the popup
 
     // Check if skill is already tagged
-    bool alreadyTagged = (skill == gCharacterEditorTempTaggedSkills[0] || skill == gCharacterEditorTempTaggedSkills[1] || skill == gCharacterEditorTempTaggedSkills[2] || skill == gCharacterEditorTempTaggedSkills[3]);
+    bool alreadyTagged = (skill == gCharacterEditorTempTaggedSkills[0] ||
+                          skill == gCharacterEditorTempTaggedSkills[1] ||
+                          skill == gCharacterEditorTempTaggedSkills[2] ||
+                          skill == gCharacterEditorTempTaggedSkills[3]);
 
     if (alreadyTagged) {
         // Remove the skill (successful toggle)
@@ -5807,16 +5810,24 @@ static void characterEditorToggleTaggedSkill(int skill)
         }
     }
 
-    // Recalculate count
-    int newCount = 0;
+    // Recalculate selected count
+    int selectedCount = 0;
     for (int i = 0; i < 3; i++) {
-        if (gCharacterEditorTempTaggedSkills[i] != -1) newCount++;
+        if (gCharacterEditorTempTaggedSkills[i] != -1) selectedCount++;
     }
-    gCharacterEditorTaggedSkillCount = newCount;
+    // Set remaining count (creation mode only)
+    if (gCharacterEditorIsCreationMode) {
+        gCharacterEditorTaggedSkillCount = 3 - selectedCount;
+    } else {
+        gCharacterEditorTaggedSkillCount = selectedCount; // fallback
+    }
 
-    // Sync all buttons (alwauys run)
+    // Sync all buttons (always run)
     for (int idx = 0; idx < SKILL_COUNT; idx++) {
-        int isTagged = (idx == gCharacterEditorTempTaggedSkills[0] || idx == gCharacterEditorTempTaggedSkills[1] || idx == gCharacterEditorTempTaggedSkills[2] || idx == gCharacterEditorTempTaggedSkills[3]);
+        int isTagged = (idx == gCharacterEditorTempTaggedSkills[0] ||
+                        idx == gCharacterEditorTempTaggedSkills[1] ||
+                        idx == gCharacterEditorTempTaggedSkills[2] ||
+                        idx == gCharacterEditorTempTaggedSkills[3]);
         _win_set_button_rest_state(gCharacterEditorTagSkillBtns[idx], isTagged ? 1 : 0, 1);
     }
 

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -915,6 +915,26 @@ struct CustomKarmaFolderDescription {
 static std::vector<CustomKarmaFolderDescription> gCustomKarmaFolderDescriptions;
 static std::vector<TownReputationEntry> gCustomTownReputationEntries;
 
+static void characterEditorSyncButtonStates()
+{
+    if (!gCharacterEditorIsCreationMode) return;
+
+    // Tag Skills
+    for (int idx = 0; idx < SKILL_COUNT; idx++) {
+        int isTagged = (idx == gCharacterEditorTempTaggedSkills[0] ||
+                        idx == gCharacterEditorTempTaggedSkills[1] ||
+                        idx == gCharacterEditorTempTaggedSkills[2] ||
+                        idx == gCharacterEditorTempTaggedSkills[3]);
+        _win_set_button_rest_state(gCharacterEditorTagSkillBtns[idx], isTagged ? 1 : 0, 0); // flags=0: no event
+    }
+
+    // Optional Traits
+    for (int idx = 0; idx < TRAIT_COUNT; idx++) {
+        int isSelected = (idx == gCharacterEditorTempTraits[0] || idx == gCharacterEditorTempTraits[1]);
+        _win_set_button_rest_state(gCharacterEditorOptionalTraitBtns[idx], isSelected ? 1 : 0, 0);
+    }
+}
+
 // 0x431DF8
 int characterEditorShow(bool isCreationMode)
 {
@@ -2035,6 +2055,7 @@ static int characterEditorWindowInit()
         buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
     }
 
+    characterEditorSyncButtonStates();
     windowRefresh(gCharacterEditorWindow);
     indicatorBarHide();
 
@@ -4312,6 +4333,7 @@ static int characterEditorShowOptions()
 
                     gCharacterEditorTempTraitCount = traitCount;
                     critterUpdateDerivedStats(gDude);
+                    characterEditorSyncButtonStates();
                     characterEditorResetScreen();
                 }
             } else if (keyCode == 502 || keyCode == KEY_UPPERCASE_P || keyCode == KEY_LOWERCASE_P) {
@@ -4450,8 +4472,8 @@ static int characterEditorShowOptions()
                             gCharacterEditorTempTraitCount = traitCount;
 
                             critterUpdateDerivedStats(gDude);
-
                             critterAdjustHitPoints(gDude, 1000);
+                            characterEditorSyncButtonStates();
 
                             rc = 1;
                         } else {

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1857,7 +1857,7 @@ static int characterEditorWindowInit()
         for (i = 0; i < SKILL_COUNT; i++) {
             int eventCode = TAG_SKILLS_BUTTON_CODE + i; // 536..553
             int keyCode = eventCode;
-            if (settings.enhancements.strict_vanilla){
+            if (settings.enhancements.strict_vanilla) {
                 buttonFlags = 32;
                 keyCode = -1;
             }
@@ -1883,7 +1883,7 @@ static int characterEditorWindowInit()
         for (i = 0; i < TRAIT_COUNT / 2; i++) {
             int eventCode = OPTIONAL_TRAITS_BTN_CODE + i; // 555..562
             int keyCode = eventCode;
-            if (settings.enhancements.strict_vanilla){
+            if (settings.enhancements.strict_vanilla) {
                 buttonFlags = 32;
                 keyCode = -1;
             }
@@ -1911,7 +1911,7 @@ static int characterEditorWindowInit()
         for (i = TRAIT_COUNT / 2; i < TRAIT_COUNT; i++) {
             int eventCode = OPTIONAL_TRAITS_BTN_CODE + i; // 563..570
             int keyCode = eventCode;
-            if (settings.enhancements.strict_vanilla){
+            if (settings.enhancements.strict_vanilla) {
                 buttonFlags = 32;
                 keyCode = -1;
             }

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1852,9 +1852,15 @@ static int characterEditorWindowInit()
         }
 
         y = gOffsets.tagSkillsButtonY;
+        int buttonFlags = BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE;
         // Tag Skills
         for (i = 0; i < SKILL_COUNT; i++) {
             int eventCode = TAG_SKILLS_BUTTON_CODE + i; // 536..553
+            int keyCode = eventCode;
+            if (settings.enhancements.strict_vanilla){
+                buttonFlags = 32;
+                keyCode = -1;
+            }
             gCharacterEditorTagSkillBtns[i] = buttonCreate(
                 gCharacterEditorWindow,
                 gOffsets.tagSkillsButtonX,
@@ -1862,12 +1868,12 @@ static int characterEditorWindowInit()
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getWidth(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight(),
                 -1, -1,
-                eventCode, // keyCode = eventCode
+                keyCode, // keyCode = eventCode
                 eventCode, // eventCode = same value
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_OFF].getData(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getData(),
                 nullptr,
-                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE);
+                buttonFlags);
             buttonSetCallbacks(gCharacterEditorTagSkillBtns[i], _gsound_red_butt_press, nullptr);
             y += _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight();
         }
@@ -1876,18 +1882,23 @@ static int characterEditorWindowInit()
         // Optional Traits (left column)
         for (i = 0; i < TRAIT_COUNT / 2; i++) {
             int eventCode = OPTIONAL_TRAITS_BTN_CODE + i; // 555..562
+            int keyCode = eventCode;
+            if (settings.enhancements.strict_vanilla){
+                buttonFlags = 32;
+                keyCode = -1;
+            }
             gCharacterEditorOptionalTraitBtns[i] = buttonCreate(
                 gCharacterEditorWindow,
                 gOffsets.optionalTraitsLeftButtonX,
                 y,
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getWidth(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight(),
-                -1, -1, eventCode,
+                -1, -1, keyCode,
                 eventCode,
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_OFF].getData(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getData(),
                 nullptr,
-                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE);
+                buttonFlags);
             buttonSetCallbacks(gCharacterEditorOptionalTraitBtns[i], _gsound_red_butt_press, nullptr);
             y += _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight() + OPTIONAL_TRAITS_BTN_SPACE;
             if (i == TRAIT_COUNT / 2 - 3) {
@@ -1899,18 +1910,23 @@ static int characterEditorWindowInit()
         // Optional Traits (right column)
         for (i = TRAIT_COUNT / 2; i < TRAIT_COUNT; i++) {
             int eventCode = OPTIONAL_TRAITS_BTN_CODE + i; // 563..570
+            int keyCode = eventCode;
+            if (settings.enhancements.strict_vanilla){
+                buttonFlags = 32;
+                keyCode = -1;
+            }
             gCharacterEditorOptionalTraitBtns[i] = buttonCreate(
                 gCharacterEditorWindow,
                 gOffsets.optionalTraitsRightButtonX,
                 y,
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getWidth(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight(),
-                -1, -1, eventCode,
+                -1, -1, keyCode,
                 eventCode,
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_OFF].getData(),
                 _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getData(),
                 nullptr,
-                BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE);
+                buttonFlags);
             buttonSetCallbacks(gCharacterEditorOptionalTraitBtns[i], _gsound_red_butt_press, nullptr);
             y += _editorFrmImages[EDITOR_GRAPHIC_TAG_SKILL_BUTTON_ON].getHeight() + OPTIONAL_TRAITS_BTN_SPACE;
             if (i == TRAIT_COUNT - 3) {
@@ -5818,7 +5834,7 @@ static void characterEditorToggleTaggedSkill(int skill)
             lastFailedSkill = -1; // success, clear the guard
         } else {
             // Too many – show popup only if this is a different skill
-            if (skill != lastFailedSkill) {
+            if (skill != lastFailedSkill || settings.enhancements.strict_vanilla) {
                 soundPlayFile("iisxxxx1");
                 char line1[128];
                 strcpy(line1, getmsg(&gCharacterEditorMessageList, &gCharacterEditorMessageListItem, 140));
@@ -5987,7 +6003,7 @@ static void characterEditorToggleOptionalTrait(int trait)
             lastFailedTrait = -1;
         } else {
             // Too many – show popup only if this is a different trait
-            if (trait != lastFailedTrait) {
+            if (trait != lastFailedTrait || settings.enhancements.strict_vanilla) {
                 soundPlayFile("iisxxxx1");
                 char line1[128];
                 strcpy(line1, getmsg(&gCharacterEditorMessageList, &gCharacterEditorMessageListItem, 148));


### PR DESCRIPTION
This fixes a long standing issue I had with the Character Editor - tagged skills' and traits' will now remain toggled with the button light 'on'

- Add actual button toggling to represent selected skills/traits in Character Editor
- Use explicit eventCode variables and enable BUTTON_FLAG_TRANSPARENT | BUTTON_FLAG_CHECKABLE for tag-skill and optional-trait buttons.
- Refactor characterEditorToggleTaggedSkill and characterEditorToggleOptionalTrait to simplify add/remove logic, recalculate counts, and always sync button states.
- Add guards (lastFailedSkill/lastFailedTrait) to avoid repeating the "too many" popup for the same item.
- Keep existing sounds/dialogs but only show them once per offending skill/trait. Minor comments and formatting improvements for clarity.

<img width="1985" height="1241" alt="Screenshot 2026-08-14 at 23 15 05" src="https://github.com/user-attachments/assets/c4df2468-f116-45ab-ab0c-7d0c38ab4f21" />

