### PR TITLE
Prefer mod version string as window title

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -176,6 +176,9 @@ int gameInitWithOptions(const char* windowTitle, bool isMapper, int font, int fl
     messageListRepositoryInit();
 
     programWindowSetTitle(windowTitle);
+    if (!settings.mod_settings.version_string.empty()) {
+        programWindowSetTitle(settings.mod_settings.version_string.c_str());
+    }
     scriptWindowInit(1, flags);
     paletteInit();
 

--- a/src/game.cc
+++ b/src/game.cc
@@ -175,10 +175,11 @@ int gameInitWithOptions(const char* windowTitle, bool isMapper, int font, int fl
     // it should be initialized early in the process.
     messageListRepositoryInit();
 
-    programWindowSetTitle(windowTitle);
-    if (!settings.mod_settings.version_string.empty()) {
-        programWindowSetTitle(settings.mod_settings.version_string.c_str());
-    }
+    // Set game name and version
+    char version[VERSION_MAX];
+    versionGetVersion(version, sizeof(version));
+    programWindowSetTitle(version);
+
     scriptWindowInit(1, flags);
     paletteInit();
 


### PR DESCRIPTION
### Description

- Use versionGetVersion as the source of truth for the window title. Set once.

- Inspired by https://github.com/fallout2-ce/fallout2-ce/pull/685/changes#diff-a0aefbe0c1ab106548c53d1e0822f37c84384f74c01d40bb4668e30e1bdbe6a9R174