### PR TITLE
Guard skill lookups for non-critter objects

### DIFF
--- a/src/skill.cc
+++ b/src/skill.cc
@@ -281,8 +281,15 @@ int skillGetBaseValue(Object* obj, int skill)
         return 0;
     }
 
-    Proto* proto;
-    protoGetProto(obj->pid, &proto);
+    // Only critters have skills
+    if (PID_TYPE(obj->pid) != OBJ_TYPE_CRITTER) {
+        return 0;
+    }
+
+    Proto* proto = nullptr;
+    if (protoGetProto(obj->pid, &proto) == -1) {
+        return 0;
+    }
 
     return proto->critter.data.skills[skill];
 }


### PR DESCRIPTION
Prevent crashes when a non-critter object or a missing proto is queried for a skill value. The function now returns 0 for unsupported object types and when proto lookup fails, avoiding invalid skill access.

The game crashed when moving between maps in the Den, with an error about reading memory that had been freed. The crash occurred while running a script (DCCustmr.int) that checked whether a character could see another object. Somehow an object without skills was passed to skillGetBaseValue.