### PR TITLE
Check script exists before clearing source

### DIFF
--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -1351,6 +1351,10 @@ int scriptExecProc(int sid, int proc)
     }
 
     if (procedureIndex == -1) {
+        // **FIX: Only set source to nullptr if the script still exists**
+        if (scriptGetScript(sid, &script) != -1) {
+            script->source = nullptr;
+        }
         return -1;
     }
 
@@ -1358,7 +1362,11 @@ int scriptExecProc(int sid, int proc)
 
     programExecuteProcedure(program, procedureIndex);
 
-    script->source = nullptr;
+    // **FIX: After execution, re-fetch the script pointer.**
+    // If it was removed during execution, skip writing to it.
+    if (scriptGetScript(sid, &script) != -1) {
+        script->source = nullptr;
+    }
 
     return 0;
 }


### PR DESCRIPTION
Prevent potential use-after-free by ensuring the script still exists before writing to script->source. Adds scriptGetScript(sid, &script) checks in the 'procedure not found' path and after executing a procedure, and includes comments explaining the guard. This avoids clearing source on a removed script and prevents invalid memory access.

Fix for exit crash in Modoc