### PR TITLE
Fix speech audio path lookup and WAV support

### DIFF
--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -1179,7 +1179,7 @@ Sound* soundEffectLoad(const char* name, Object* object)
             debugPrint("soundEffectLoad: Found WAV file: %s\n", path);
         }
         rc = soundSetFileIO(sound, wavOpen, wavClose, wavRead, nullptr,
-                            wavSeek, wavTell, wavGetSize);
+            wavSeek, wavTell, wavGetSize);
         if (rc != 0) {
             if (gGameSoundDebugEnabled) {
                 debugPrint("soundEffectLoad: Failed to set WAV I/O (rc=%d)\n", rc);

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -965,7 +965,7 @@ int speechLoad(const char* fileName, GameSoundReadLimitMode readLimitMode, GameS
             debugPrint("speechLoad: Found WAV file: %s\n", path);
         }
         rc = soundSetFileIO(gSpeechSound, wavOpen, wavClose, wavRead, nullptr,
-                            wavSeek, wavTell, wavGetSize);
+            wavSeek, wavTell, wavGetSize);
         if (rc != 0) {
             if (gGameSoundDebugEnabled) {
                 debugPrint("speechLoad: Failed to set WAV I/O (rc=%d)\n", rc);
@@ -979,7 +979,7 @@ int speechLoad(const char* fileName, GameSoundReadLimitMode readLimitMode, GameS
     } else {
         // Ensure ACM I/O (already set by _gsound_background_allocate, but set explicitly for safety)
         if (soundSetFileIO(gSpeechSound, audioOpen, audioClose, audioRead, nullptr,
-                           audioSeek, gameSoundFileTellNotImplemented, audioGetSize)) {
+                audioSeek, gameSoundFileTellNotImplemented, audioGetSize)) {
             if (gGameSoundDebugEnabled) {
                 debugPrint("failed because file IO could not be set for compression.\n");
             }

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -1146,6 +1146,7 @@ Sound* soundEffectLoad(const char* name, Object* object)
     char path[COMPAT_MAX_PATH + 1];
     Sound* sound;
     int rc;
+    bool found = false;
 
     if (!gGameSoundInitialized || !gSoundEffectsEnabled) {
         return nullptr;
@@ -1171,16 +1172,14 @@ Sound* soundEffectLoad(const char* name, Object* object)
 
     ++_gsound_active_effect_counter;
 
-    // Check if a WAV file exists
-    bool foundWav = (gameSoundFindWavEffectPath(path, name) == 0);
-
-    if (foundWav) {
-        // Override I/O with WAV callbacks
+    // Try WAV (using the WAV-only finder)
+    if (gameSoundFindWavEffectPath(path, name) == 0) {
+        found = true;
         if (gGameSoundDebugEnabled) {
             debugPrint("soundEffectLoad: Found WAV file: %s\n", path);
         }
         rc = soundSetFileIO(sound, wavOpen, wavClose, wavRead, nullptr,
-            wavSeek, wavTell, wavGetSize);
+                            wavSeek, wavTell, wavGetSize);
         if (rc != 0) {
             if (gGameSoundDebugEnabled) {
                 debugPrint("soundEffectLoad: Failed to set WAV I/O (rc=%d)\n", rc);
@@ -1190,25 +1189,106 @@ Sound* soundEffectLoad(const char* name, Object* object)
             return nullptr;
         }
         sound->isWav = true;
-    } else {
-        // No WAV found: use original ACM path
-        if (gGameSoundDebugEnabled) {
-            debugPrint("soundEffectLoad: No WAV found, using ACM path\n");
-        }
-        // Default I/O is already set by _gsound_get_sound_ready_for_effect
-        // Build the ACM path using the original method
-        snprintf(path, sizeof(path), "%s%s%s", _sound_sfx_path, name, ".ACM");
+        goto load;
     }
 
-    // Load the sound (WAV or ACM)
+    // Try primary ACM path
+    snprintf(path, sizeof(path), "%s%s%s", _sound_sfx_path, name, ".ACM");
+    if (gGameSoundDebugEnabled) {
+        debugPrint("soundEffectLoad: Trying ACM path: %s\n", path);
+    }
     rc = soundLoad(sound, path);
-    if (rc != 0) {
+    if (rc == 0) {
+        found = true;
+        sound->isWav = false;
+        goto load;
+    }
+
+    // Alias handling (original logic)
+    if (object != nullptr) {
+        if (FID_TYPE(object->fid) == OBJ_TYPE_CRITTER && (name[0] == 'H' || name[0] == 'N')) {
+            char v9 = name[1];
+            if (v9 == 'A' || v9 == 'F' || v9 == 'M') {
+                if (v9 == 'A') {
+                    if (critterGetStat(object, STAT_GENDER)) {
+                        v9 = 'F';
+                    } else {
+                        v9 = 'M';
+                    }
+                }
+            }
+
+            // Try H%cXXXX%s.ACM
+            char aliasPath[COMPAT_MAX_PATH + 1];
+            snprintf(aliasPath, sizeof(aliasPath), "%sH%cXXXX%s%s", _sound_sfx_path, v9, name + 6, ".ACM");
+            if (gGameSoundDebugEnabled) {
+                debugPrint("soundEffectLoad: Trying alias: %s\n", aliasPath + strlen(_sound_sfx_path));
+            }
+            rc = soundLoad(sound, aliasPath);
+            if (rc == 0) {
+                strcpy(path, aliasPath);
+                found = true;
+                sound->isWav = false;
+                goto load;
+            }
+
+            // If female and failed, try male alias
+            if (v9 == 'F') {
+                snprintf(aliasPath, sizeof(aliasPath), "%sHMXXXX%s%s", _sound_sfx_path, name + 6, ".ACM");
+                if (gGameSoundDebugEnabled) {
+                    debugPrint("soundEffectLoad: Trying male alias: %s\n", aliasPath + strlen(_sound_sfx_path));
+                }
+                rc = soundLoad(sound, aliasPath);
+                if (rc == 0) {
+                    strcpy(path, aliasPath);
+                    found = true;
+                    sound->isWav = false;
+                    goto load;
+                }
+            }
+        }
+    }
+
+    // MAMTNT alias
+    if (strncmp(name, "MALIEU", 6) == 0 || strncmp(name, "MAMTN2", 6) == 0) {
+        char aliasPath[COMPAT_MAX_PATH + 1];
+        snprintf(aliasPath, sizeof(aliasPath), "%sMAMTNT%s%s", _sound_sfx_path, name + 6, ".ACM");
         if (gGameSoundDebugEnabled) {
-            debugPrint("soundEffectLoad: soundLoad failed with rc=%d\n", rc);
+            debugPrint("soundEffectLoad: Trying MAMTNT alias: %s\n", aliasPath + strlen(_sound_sfx_path));
+        }
+        rc = soundLoad(sound, aliasPath);
+        if (rc == 0) {
+            strcpy(path, aliasPath);
+            found = true;
+            sound->isWav = false;
+            goto load;
+        }
+    }
+
+    // All attempts failed
+    if (!found) {
+        if (gGameSoundDebugEnabled) {
+            debugPrint("soundEffectLoad: All attempts failed.\n");
         }
         --_gsound_active_effect_counter;
         soundDelete(sound);
         return nullptr;
+    }
+
+load:
+    // ----- Final load (only if we set I/O for WAV; for ACM we already loaded) -----
+    // For ACM, we already called soundLoad above, so we should not call it again.
+    // But for WAV, we need to load after setting I/O.
+    if (found && sound->isWav) {
+        rc = soundLoad(sound, path);
+        if (rc != 0) {
+            if (gGameSoundDebugEnabled) {
+                debugPrint("soundEffectLoad: WAV soundLoad failed with rc=%d\n", rc);
+            }
+            --_gsound_active_effect_counter;
+            soundDelete(sound);
+            return nullptr;
+        }
     }
 
     if (gGameSoundDebugEnabled) debugPrint("succeeded.\n");

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -173,7 +173,6 @@ static void backgroundSoundCallback(void* userData, int event);
 static void soundEffectCallback(void* userData, int event);
 static int _gsound_background_allocate(Sound** outSound, GameSoundStorageType storageType, GameSoundLoopingMode loopingMode);
 static int gameSoundFindBackgroundSoundPath(char* dest, const char* src);
-static int gameSoundFindSpeechSoundPath(char* dest, const char* src);
 static int gameSoundFindWavEffectPath(char* dest, const char* src);
 static int backgroundSoundPlay();
 static int speechPlay();
@@ -182,7 +181,7 @@ static Sound* _gsound_get_sound_ready_for_effect();
 static bool _gsound_file_exists_f(const char* fname);
 static int _gsound_setup_paths();
 
-static bool isWavFile(const char* path)
+bool isWavFile(const char* path)
 {
     const char* ext = strrchr(path, '.');
     if (!ext) return false;
@@ -929,13 +928,8 @@ int speechLoad(const char* fileName, GameSoundReadLimitMode readLimitMode, GameS
 {
     char path[COMPAT_MAX_PATH + 1];
     int rc;
-    bool foundWav;
 
-    if (!gGameSoundInitialized) {
-        return -1;
-    }
-
-    if (!gSpeechEnabled) {
+    if (!gGameSoundInitialized || !gSpeechEnabled) {
         return -1;
     }
 
@@ -943,7 +937,6 @@ int speechLoad(const char* fileName, GameSoundReadLimitMode readLimitMode, GameS
         debugPrint("Loading speech sound file %s%s...", fileName, ".ACM");
     }
 
-    // Delete any existing speech sound
     speechDelete();
 
     // Allocate sound (default I/O is ACM)
@@ -965,16 +958,14 @@ int speechLoad(const char* fileName, GameSoundReadLimitMode readLimitMode, GameS
         return -1;
     }
 
-    // Determine if WAV or ACM
-    foundWav = isWavFile(path);
-
-    if (foundWav) {
-        // Override I/O with WAV callbacks
+    // Determine if it's a WAV file and override I/O if needed
+    bool isWav = isWavFile(path);
+    if (isWav) {
         if (gGameSoundDebugEnabled) {
             debugPrint("speechLoad: Found WAV file: %s\n", path);
         }
         rc = soundSetFileIO(gSpeechSound, wavOpen, wavClose, wavRead, nullptr,
-            wavSeek, wavTell, wavGetSize);
+                            wavSeek, wavTell, wavGetSize);
         if (rc != 0) {
             if (gGameSoundDebugEnabled) {
                 debugPrint("speechLoad: Failed to set WAV I/O (rc=%d)\n", rc);
@@ -986,27 +977,46 @@ int speechLoad(const char* fileName, GameSoundReadLimitMode readLimitMode, GameS
         // Mark as WAV so soundLoad can extract parameters
         gSpeechSound->isWav = true;
     } else {
-        // ACM - keep the default I/O (already set by allocation)
-        if (gGameSoundDebugEnabled) {
-            debugPrint("speechLoad: Found ACM file: %s\n", path);
+        // Ensure ACM I/O (already set by _gsound_background_allocate, but set explicitly for safety)
+        if (soundSetFileIO(gSpeechSound, audioOpen, audioClose, audioRead, nullptr,
+                           audioSeek, gameSoundFileTellNotImplemented, audioGetSize)) {
+            if (gGameSoundDebugEnabled) {
+                debugPrint("failed because file IO could not be set for compression.\n");
+            }
+            soundDelete(gSpeechSound);
+            gSpeechSound = nullptr;
+            return -1;
         }
-        // The I/O was set by _gsound_background_allocate (which uses audioOpen)
-        // No override needed.
+        gSpeechSound->isWav = false;
     }
 
-    // Set read limit (if requested)
+    // Continue with original loading logic
+    if (loopingMode == GSOUND_LOOP) {
+        if (soundSetLooping(gSpeechSound, 0xFFFF)) {
+            if (gGameSoundDebugEnabled) {
+                debugPrint("failed because looping could not be set.\n");
+            }
+            soundDelete(gSpeechSound);
+            gSpeechSound = nullptr;
+            return -1;
+        }
+    }
+
+    if (soundSetCallback(gSpeechSound, speechCallback, nullptr)) {
+        if (gGameSoundDebugEnabled) {
+            debugPrint("soundSetCallback failed for speech sound\n");
+        }
+    }
+
     if (readLimitMode == GSOUND_LIMIT_BEFORE) {
-        rc = soundSetReadLimit(gSpeechSound, 0x40000);
-        if (rc != SOUND_NO_ERROR) {
+        if (soundSetReadLimit(gSpeechSound, 0x40000)) {
             if (gGameSoundDebugEnabled) {
                 debugPrint("unable to set read limit ");
             }
         }
     }
 
-    // Load the sound
-    rc = soundLoad(gSpeechSound, path);
-    if (rc != SOUND_NO_ERROR) {
+    if (soundLoad(gSpeechSound, path)) {
         if (gGameSoundDebugEnabled) {
             debugPrint("failed on call to soundLoad.\n");
         }
@@ -1016,8 +1026,7 @@ int speechLoad(const char* fileName, GameSoundReadLimitMode readLimitMode, GameS
     }
 
     if (readLimitMode != GSOUND_LIMIT_BEFORE) {
-        rc = soundSetReadLimit(gSpeechSound, 0x40000);
-        if (rc != 0) {
+        if (soundSetReadLimit(gSpeechSound, 0x40000)) {
             if (gGameSoundDebugEnabled) {
                 debugPrint("unable to set read limit ");
             }
@@ -1028,8 +1037,7 @@ int speechLoad(const char* fileName, GameSoundReadLimitMode readLimitMode, GameS
         return 0;
     }
 
-    // Play the speech
-    if (speechPlay() != 0) {
+    if (speechPlay()) {
         if (gGameSoundDebugEnabled) {
             debugPrint("failed starting to play.\n");
         }
@@ -1788,7 +1796,7 @@ int gameSoundFindBackgroundSoundPath(char* dest, const char* src)
 }
 
 // 0x451F94
-static int gameSoundFindSpeechSoundPath(char* dest, const char* src)
+int gameSoundFindSpeechSoundPath(char* dest, const char* src)
 {
     char path[COMPAT_MAX_PATH + 1];
     char upperSrc[COMPAT_MAX_PATH + 1];

--- a/src/game_sound.h
+++ b/src/game_sound.h
@@ -103,6 +103,8 @@ void _gsound_lrg_butt_release(int btn, int keyCode);
 int soundPlayFile(const char* name);
 int _gsound_sfx_q_start();
 int ambientSoundEffectEventProcess(Object* object, void* data);
+int gameSoundFindSpeechSoundPath(char* dest, const char* src);
+bool isWavFile(const char* path);
 
 } // namespace fallout
 

--- a/src/lips.cc
+++ b/src/lips.cc
@@ -465,7 +465,7 @@ static int _lips_make_speech()
     bool isWav = isWavFile(path);
     if (isWav) {
         if (soundSetFileIO(gLipsData.sound, wavOpen, wavClose, wavRead, nullptr,
-                           wavSeek, wavTell, wavGetSize)) {
+                wavSeek, wavTell, wavGetSize)) {
             debugPrint("Failed to set WAV I/O in lips_make_speech\n");
             soundDelete(gLipsData.sound);
             gLipsData.sound = nullptr;
@@ -474,7 +474,7 @@ static int _lips_make_speech()
         gLipsData.sound->isWav = true;
     } else {
         if (soundSetFileIO(gLipsData.sound, audioOpen, audioClose, audioRead, nullptr,
-                           audioSeek, nullptr, audioGetSize)) {
+                audioSeek, nullptr, audioGetSize)) {
             debugPrint("Failed to set ACM I/O in lips_make_speech\n");
             soundDelete(gLipsData.sound);
             gLipsData.sound = nullptr;
@@ -496,7 +496,7 @@ static int _lips_make_speech()
         float scale = (float)gLipsData.sound->rate / 22050.0f;
         if (scale != 1.0f) {
             debugPrint("lips_make_speech: scaling markers by %.2f (rate=%d)\n",
-                       scale, gLipsData.sound->rate);
+                scale, gLipsData.sound->rate);
             for (int i = 0; i < gLipsData.field_2C; i++) {
                 gLipsData.markers[i].position = (int)(gLipsData.markers[i].position * scale);
             }

--- a/src/lips.cc
+++ b/src/lips.cc
@@ -12,6 +12,7 @@
 #include "platform_compat.h"
 #include "sound.h"
 #include "svga.h"
+#include "wav_io.h"
 
 namespace fallout {
 
@@ -441,9 +442,9 @@ static int _lips_make_speech()
         gLipsData.field_14 = nullptr;
     }
 
-    char path[COMPAT_MAX_PATH];
     char* v1 = lips_fix_string(gLipsData.file_name, sizeof(gLipsData.file_name));
-    snprintf(path, sizeof(path), "%s%s\\%s.%s", "SOUND\\SPEECH\\", _lips_subdir_name, v1, "ACM");
+    char relPath[COMPAT_MAX_PATH];
+    snprintf(relPath, sizeof(relPath), "%s/%s", _lips_subdir_name, v1);
 
     if (gLipsData.sound != nullptr) {
         soundDelete(gLipsData.sound);
@@ -452,22 +453,54 @@ static int _lips_make_speech()
 
     gLipsData.sound = soundAllocate(SOUND_TYPE_MEMORY, SOUND_16BIT);
     if (gLipsData.sound == nullptr) {
-        debugPrint("\nsoundAllocate falied in lips_make_speech!");
+        debugPrint("\nsoundAllocate failed in lips_make_speech!");
         return -1;
     }
 
-    if (soundSetFileIO(gLipsData.sound, audioOpen, audioClose, audioRead, nullptr, audioSeek, nullptr, audioGetSize)) {
-        debugPrint("Ack!");
-        debugPrint("Error!");
+    char path[COMPAT_MAX_PATH + 1];
+    if (gameSoundFindSpeechSoundPath(path, relPath) != 0) {
+        snprintf(path, sizeof(path), "%s%s\\%s.%s", "SOUND\\SPEECH\\", _lips_subdir_name, v1, "ACM");
+    }
+
+    bool isWav = isWavFile(path);
+    if (isWav) {
+        if (soundSetFileIO(gLipsData.sound, wavOpen, wavClose, wavRead, nullptr,
+                           wavSeek, wavTell, wavGetSize)) {
+            debugPrint("Failed to set WAV I/O in lips_make_speech\n");
+            soundDelete(gLipsData.sound);
+            gLipsData.sound = nullptr;
+            return -1;
+        }
+        gLipsData.sound->isWav = true;
+    } else {
+        if (soundSetFileIO(gLipsData.sound, audioOpen, audioClose, audioRead, nullptr,
+                           audioSeek, nullptr, audioGetSize)) {
+            debugPrint("Failed to set ACM I/O in lips_make_speech\n");
+            soundDelete(gLipsData.sound);
+            gLipsData.sound = nullptr;
+            return -1;
+        }
+        gLipsData.sound->isWav = false;
     }
 
     if (soundLoad(gLipsData.sound, path)) {
         soundDelete(gLipsData.sound);
         gLipsData.sound = nullptr;
-
         debugPrint("lips_make_speech: soundLoad failed with path ");
         debugPrint("%s -- file probably doesn't exist.\n", path);
         return -1;
+    }
+
+    // Scale markers if WAV has different sample rate
+    if (gLipsData.sound->isWav && gLipsData.markers != nullptr) {
+        float scale = (float)gLipsData.sound->rate / 22050.0f;
+        if (scale != 1.0f) {
+            debugPrint("lips_make_speech: scaling markers by %.2f (rate=%d)\n",
+                       scale, gLipsData.sound->rate);
+            for (int i = 0; i < gLipsData.field_2C; i++) {
+                gLipsData.markers[i].position = (int)(gLipsData.markers[i].position * scale);
+            }
+        }
     }
 
     gLipsData.field_34 = 8 * (gLipsData.field_1C / gLipsData.field_2C);


### PR DESCRIPTION
This change fixes speech loading for both ACM and WAV files by making the speech path resolver visible and handling WAV/ACM file I/O explicitly in the speech loader. It also updates lip-sync playback to resolve speech assets through the game sound search path and scales markers when a WAV file uses a different sample rate.

- Improve sound effect lookup in game_sound.cc by trying WAV files first, then falling back through the primary ACM path and alias variants used for critter/gender-specific effects. This keeps the existing sound-loading flow intact while handling missing WAVs and alternate filenames without returning a failed load prematurely.

Fixes #155 and #156 and #157