### PR TITLE
Worldmap + Load/Save Fixes

### DIFF
--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -691,8 +691,8 @@ int lsgSaveGame(int mode)
     case SLOT_STATE_UNSUPPORTED_VERSION:
         blitBufferToBufferStretch(
             _snapshotBuf,
-            LS_PREVIEW_WIDTH,
-            LS_PREVIEW_HEIGHT,
+            LS_PREVIEW_WIDTH - 1,
+            LS_PREVIEW_HEIGHT - 1,
             LS_PREVIEW_WIDTH,
             gLoadSaveWindowBuffer + gOffsets.windowWidth * gOffsets.previewY + gOffsets.previewX,
             gOffsets.previewWidth,

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -697,8 +697,7 @@ int lsgSaveGame(int mode)
             gLoadSaveWindowBuffer + gOffsets.windowWidth * gOffsets.previewY + gOffsets.previewX,
             gOffsets.previewWidth,
             gOffsets.previewHeight,
-            gOffsets.windowWidth
-        );
+            gOffsets.windowWidth);
         break;
     default:
         _LoadTumbSlot(_slot_cursor);

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -689,12 +689,16 @@ int lsgSaveGame(int mode)
     case SLOT_STATE_EMPTY:
     case SLOT_STATE_ERROR:
     case SLOT_STATE_UNSUPPORTED_VERSION:
-        blitBufferToBuffer(_snapshotBuf,
-            gOffsets.previewWidth - 1,
-            gOffsets.previewHeight - 1,
-            gOffsets.previewWidth,
+        blitBufferToBufferStretch(
+            _snapshotBuf,
+            LS_PREVIEW_WIDTH,
+            LS_PREVIEW_HEIGHT,
+            LS_PREVIEW_WIDTH,
             gLoadSaveWindowBuffer + gOffsets.windowWidth * gOffsets.previewY + gOffsets.previewX,
-            gOffsets.windowWidth);
+            gOffsets.previewWidth,
+            gOffsets.previewHeight,
+            gOffsets.windowWidth
+        );
         break;
     default:
         _LoadTumbSlot(_slot_cursor);
@@ -1887,33 +1891,33 @@ static int lsgWindowInit(int windowType)
 
     // Handle preview snapshot capture
     if (windowType == LOAD_SAVE_WINDOW_TYPE_SAVE_GAME || windowType == LOAD_SAVE_WINDOW_TYPE_PICK_QUICK_SAVE_SLOT) {
-
         bool gameMouseWasVisible = gameMouseObjectsIsVisible();
-        if (gameMouseWasVisible) {
-            gameMouseObjectsHide();
-        }
-
+        if (gameMouseWasVisible) gameMouseObjectsHide();
         mouseHideCursor();
         tileWindowRefresh();
         mouseShowCursor();
+        if (gameMouseWasVisible) gameMouseObjectsShow();
 
-        if (gameMouseWasVisible) {
-            gameMouseObjectsShow();
-        }
-
-        // Capture preview using loaded preview dimensions
         Window* window = windowGetWindow(gIsoWindow);
-        unsigned char* isoWindowBuffer = window->buffer
-            + window->width * (window->height - ORIGINAL_ISO_WINDOW_HEIGHT) / 2
-            + (window->width - ORIGINAL_ISO_WINDOW_WIDTH) / 2;
-        blitBufferToBufferStretch(isoWindowBuffer,
-            ORIGINAL_ISO_WINDOW_WIDTH,
-            ORIGINAL_ISO_WINDOW_HEIGHT,
-            windowGetWidth(gIsoWindow),
-            _snapshotBuf,
-            LS_PREVIEW_WIDTH,
-            LS_PREVIEW_HEIGHT,
-            LS_PREVIEW_WIDTH);
+        int winWidth = window->width;
+        int winHeight = window->height;
+        unsigned char* winBuf = window->buffer;
+
+        // Offset to the 640x480 game area
+        int offY = (winHeight - ORIGINAL_ISO_WINDOW_HEIGHT) / 2;
+        int offX = (winWidth - ORIGINAL_ISO_WINDOW_WIDTH) / 2;
+        unsigned char* srcStart = winBuf + offY * winWidth + offX;
+
+        // Shrink directly to _snapshotBuf (224x133) using nearest?neighbor
+        for (int destY = 0; destY < LS_PREVIEW_HEIGHT; destY++) {
+            int srcY = (destY * ORIGINAL_ISO_WINDOW_HEIGHT) / LS_PREVIEW_HEIGHT;
+            unsigned char* srcRow = srcStart + srcY * winWidth;
+            unsigned char* destRow = _snapshotBuf + destY * LS_PREVIEW_WIDTH;
+            for (int destX = 0; destX < LS_PREVIEW_WIDTH; destX++) {
+                int srcX = (destX * ORIGINAL_ISO_WINDOW_WIDTH) / LS_PREVIEW_WIDTH;
+                destRow[destX] = srcRow[srcX];
+            }
+        }
     }
 
     // Load interface images
@@ -2938,9 +2942,7 @@ static int _LoadTumbSlot(int slot)
             return -1;
         }
 
-        // Use dynamic preview size
-        int previewSize = gOffsets.previewWidth * gOffsets.previewHeight;
-        if (fileRead(_thumbnail_image, previewSize, 1, stream) != 1) {
+        if (fileRead(_thumbnail_image, LS_PREVIEW_SIZE, 1, stream) != 1) {
             debugPrint("\nLOADSAVE: ** (C) Error reading thumbnail #%d! **\n", slot);
             fileClose(stream);
             return -1;

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -5463,7 +5463,7 @@ static int wmWorldMapFunc(int a1)
                            gOffsets.scrollAreaY + 178)) // Height remains constant)
             {
                 if (wheelY != 0) {
-                    wmInterfaceScrollTabsStart(wheelY > 0 ? 27 : -27);
+                    wmInterfaceScrollTabsStart(wheelY > 0 ? -27 : 27);
                 }
             }
         }

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -7185,16 +7185,24 @@ static void wmMouseBkProc()
 
     if (dx != 0 || dy != 0) {
         if (dx > 0) {
-            if (dy > 0) newMouseCursor = MOUSE_CURSOR_SCROLL_SE;
-            else if (dy < 0) newMouseCursor = MOUSE_CURSOR_SCROLL_NE;
-            else newMouseCursor = MOUSE_CURSOR_SCROLL_E;
+            if (dy > 0)
+                newMouseCursor = MOUSE_CURSOR_SCROLL_SE;
+            else if (dy < 0)
+                newMouseCursor = MOUSE_CURSOR_SCROLL_NE;
+            else
+                newMouseCursor = MOUSE_CURSOR_SCROLL_E;
         } else if (dx < 0) {
-            if (dy > 0) newMouseCursor = MOUSE_CURSOR_SCROLL_SW;
-            else if (dy < 0) newMouseCursor = MOUSE_CURSOR_SCROLL_NW;
-            else newMouseCursor = MOUSE_CURSOR_SCROLL_W;
+            if (dy > 0)
+                newMouseCursor = MOUSE_CURSOR_SCROLL_SW;
+            else if (dy < 0)
+                newMouseCursor = MOUSE_CURSOR_SCROLL_NW;
+            else
+                newMouseCursor = MOUSE_CURSOR_SCROLL_W;
         } else {
-            if (dy < 0) newMouseCursor = MOUSE_CURSOR_SCROLL_N;
-            else if (dy > 0) newMouseCursor = MOUSE_CURSOR_SCROLL_S;
+            if (dy < 0)
+                newMouseCursor = MOUSE_CURSOR_SCROLL_N;
+            else if (dy > 0)
+                newMouseCursor = MOUSE_CURSOR_SCROLL_S;
         }
 
         unsigned int tick = _get_bk_time();

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -7158,25 +7158,23 @@ static int wmInterfaceScrollPixel(int stepX, int stepY, int dx, int dy, bool* su
 // 0x4C32EC
 static void wmMouseBkProc()
 {
-    // 0x51DEB0
     static unsigned int lastTime = 0;
-
-    // 0x51DEB4
     static bool couldScroll = true;
 
-    int x;
-    int y;
-    mouseGetPosition(&x, &y);
+    int x, y;
+    mouseGetPositionInWindow(wmBkWin, &x, &y);
+    int winWidth = windowGetWidth(wmBkWin);
+    int winHeight = windowGetHeight(wmBkWin);
 
     int dx = 0;
-    if (x == screenGetWidth() - 1) {
+    if (x == winWidth - 1) {
         dx = 1;
     } else if (x == 0) {
         dx = -1;
     }
 
     int dy = 0;
-    if (y == screenGetHeight() - 1) {
+    if (y == winHeight - 1) {
         dy = 1;
     } else if (y == 0) {
         dy = -1;
@@ -7187,36 +7185,23 @@ static void wmMouseBkProc()
 
     if (dx != 0 || dy != 0) {
         if (dx > 0) {
-            if (dy > 0) {
-                newMouseCursor = MOUSE_CURSOR_SCROLL_SE;
-            } else if (dy < 0) {
-                newMouseCursor = MOUSE_CURSOR_SCROLL_NE;
-            } else {
-                newMouseCursor = MOUSE_CURSOR_SCROLL_E;
-            }
+            if (dy > 0) newMouseCursor = MOUSE_CURSOR_SCROLL_SE;
+            else if (dy < 0) newMouseCursor = MOUSE_CURSOR_SCROLL_NE;
+            else newMouseCursor = MOUSE_CURSOR_SCROLL_E;
         } else if (dx < 0) {
-            if (dy > 0) {
-                newMouseCursor = MOUSE_CURSOR_SCROLL_SW;
-            } else if (dy < 0) {
-                newMouseCursor = MOUSE_CURSOR_SCROLL_NW;
-            } else {
-                newMouseCursor = MOUSE_CURSOR_SCROLL_W;
-            }
+            if (dy > 0) newMouseCursor = MOUSE_CURSOR_SCROLL_SW;
+            else if (dy < 0) newMouseCursor = MOUSE_CURSOR_SCROLL_NW;
+            else newMouseCursor = MOUSE_CURSOR_SCROLL_W;
         } else {
-            if (dy < 0) {
-                newMouseCursor = MOUSE_CURSOR_SCROLL_N;
-            } else if (dy > 0) {
-                newMouseCursor = MOUSE_CURSOR_SCROLL_S;
-            }
+            if (dy < 0) newMouseCursor = MOUSE_CURSOR_SCROLL_N;
+            else if (dy > 0) newMouseCursor = MOUSE_CURSOR_SCROLL_S;
         }
 
         unsigned int tick = _get_bk_time();
         if (getTicksBetween(tick, lastTime) > 50) {
             lastTime = _get_bk_time();
-            // NOTE: Uninline.
             wmInterfaceScroll(dx, dy, &couldScroll);
         }
-
         if (!couldScroll) {
             newMouseCursor += 8;
         }


### PR DESCRIPTION
### Description

- fix to reverse the scrolling on the Townmap list - now matches physical scrolling in inventory etc.
- also fixes edge scrolling in Large and Huge play areas.
- fixes thumbnail corruption on first save of empty slot
- fixes thumbnail corruption at 800 width

Fixes #160 
Fixes #159 
Fixes #148 
Fixes #149 
