### PR TITLE
Remove generate_release_notes from CI workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -632,7 +632,6 @@ jobs:
           draft: false
           prerelease: true
           name: Fallout Fission Beta ${{ needs.get-version.outputs.version }}
-          generate_release_notes: true
           body: |
             ## Fallout Fission Beta ${{ needs.get-version.outputs.version }}
 


### PR DESCRIPTION
Removed the 'generate_release_notes' option from the release step.

