### PR TITLE
Add voiced narration to holodisks, gated behind VockFloats

### DIFF
--- a/FISSION_Modding_Guide.md
+++ b/FISSION_Modding_Guide.md
@@ -1565,6 +1565,43 @@ Create message files in language folders:
 -   Recommended range: 900-999 for small mods, higher for larger mods
 -   Set GVAR to 1 to give holodisk, 0 to remove (though typically not removed)
 
+#### 11.5.5 Voiced Narration (Audio)
+
+Holodisks share the same message-list loading path as everything else in FISSION
+(`getmsg()`/`MessageListItem`), and that path already carries a per-line audio field --
+the middle slot of the standard `{num}{audio}{text}` `.msg` triple. Holodisk rendering
+now reads that field: put an audio filename on a page's *first* line and it plays as
+voiced narration while that page is on screen.
+
+```
+{0}{}{Important Data Disk}
+{1}{holodisk\myquest_intro}{This holodisk contains critical information}
+{2}{}{about the secret facility.}
+{3}{}{**END-PAR**}
+{4}{}{The entrance is hidden behind the waterfall.}
+{5}{}{**END-DISK**}
+```
+
+Rules:
+
+-   Only the audio field on a page's first line is used -- one clip per page, not per
+    line. Lines after the first ignore their own audio field.
+-   The filename resolves exactly like any other speech line: `sound/speech/<name>.wav`
+    or `.acm` (searched in that order). Subfolders are fine (`holodisk\myquest_intro`
+    above resolves to `sound/speech/holodisk/myquest_intro.*`).
+-   Leave the audio field empty (`{}`) for a silent page. Silence is explicit --
+    it stops whatever the previous page was playing rather than leaving it running
+    under new text.
+-   Turning a page, opening a different holodisk, or leaving the Pip-Boy all stop the
+    current clip; nothing needs manual cleanup from script or data.
+-   Gated by the same switches as every other VockFloats feature: `[enhancements]
+    VockFloats=1` in `fission.cfg`, `VoicedFloats=1` in `game.cfg`'s `[vock-floats]`
+    section, and off entirely under `StrictVanilla=1`. With `VockFloats` off, holodisks
+    behave exactly as before -- text only.
+-   Applies identically to vanilla holodisks (`data/holodisk.txt` +
+    `text/english/game/PIPBOY.msg`) and mod holodisks (`holodisk_<ModName>_<BlockKey>.msg`,
+    see 11.3) -- both load through the same message-list parser.
+
 ### 11.6 Complete Example Mod
 
 File: `data/holodisk_myquest.txt`

--- a/FISSION_Modding_Guide.md
+++ b/FISSION_Modding_Guide.md
@@ -1570,8 +1570,8 @@ Create message files in language folders:
 Holodisks share the same message-list loading path as everything else in FISSION
 (`getmsg()`/`MessageListItem`), and that path already carries a per-line audio field --
 the middle slot of the standard `{num}{audio}{text}` `.msg` triple. Holodisk rendering
-now reads that field: put an audio filename on a page's *first* line and it plays as
-voiced narration while that page is on screen.
+reads that field once, from the holodisk's *very first* message line, and plays it as
+one continuous narration clip for the whole holodisk -- not one clip per page.
 
 ```
 {0}{}{Important Data Disk}
@@ -1582,19 +1582,28 @@ voiced narration while that page is on screen.
 {5}{}{**END-DISK**}
 ```
 
+Why one clip, not one per page: pagination (35 message IDs per page, see 11.5.2) is a
+blind count with no idea where a sentence ends. A real, longer holodisk's page breaks
+land mid-sentence as a matter of course -- there's no way to choose per-page cut points
+that don't eventually land there too, since the boundary shifts if the text is ever
+edited. A single clip sidesteps this entirely: it starts when the holodisk opens and
+keeps playing across page turns, so nothing needs to be cut to match an arbitrary
+35-line count.
+
 Rules:
 
--   Only the audio field on a page's first line is used -- one clip per page, not per
-    line. Lines after the first ignore their own audio field.
+-   Only the audio field on the holodisk's first message line is read (the ID in
+    `holodisk.txt`'s third column, i.e. page 0's first line). The field on every other
+    line, including the first line of later pages, is ignored.
 -   The audio field is a bare filename, same as dialogue's (e.g. `{fea1}` in a regular
     NPC `.msg`) -- never a path. The folder is fixed, not authored: it always resolves
     to `sound/speech/holodisks/<name>.wav` or `.acm` (searched in that order), the same
     way dialogue always resolves under `sound/speech/<critter's head name>/<name>`.
--   Leave the audio field empty (`{}`) for a silent page. Silence is explicit --
-    it stops whatever the previous page was playing rather than leaving it running
-    under new text.
--   Turning a page, opening a different holodisk, or leaving the Pip-Boy all stop the
-    current clip; nothing needs manual cleanup from script or data.
+-   Leave the field empty (`{}`) for a silent holodisk -- no narration plays.
+-   The clip plays once, in full, regardless of how many pages the reader turns through
+    or how long they linger on one page. Opening a *different* holodisk, or leaving the
+    Pip-Boy, stops it and clears the tracking so reopening the same holodisk later
+    restarts the clip from the top. Nothing needs manual cleanup from script or data.
 -   Gated by the same switches as every other VockFloats feature: `[enhancements]
     VockFloats=1` in `fission.cfg`, `VoicedFloats=1` in `game.cfg`'s `[vock-floats]`
     section, and off entirely under `StrictVanilla=1`. With `VockFloats` off, holodisks

--- a/FISSION_Modding_Guide.md
+++ b/FISSION_Modding_Guide.md
@@ -1575,7 +1575,7 @@ voiced narration while that page is on screen.
 
 ```
 {0}{}{Important Data Disk}
-{1}{holodisk\myquest_intro}{This holodisk contains critical information}
+{1}{myquest_intro}{This holodisk contains critical information}
 {2}{}{about the secret facility.}
 {3}{}{**END-PAR**}
 {4}{}{The entrance is hidden behind the waterfall.}
@@ -1586,9 +1586,10 @@ Rules:
 
 -   Only the audio field on a page's first line is used -- one clip per page, not per
     line. Lines after the first ignore their own audio field.
--   The filename resolves exactly like any other speech line: `sound/speech/<name>.wav`
-    or `.acm` (searched in that order). Subfolders are fine (`holodisk\myquest_intro`
-    above resolves to `sound/speech/holodisk/myquest_intro.*`).
+-   The audio field is a bare filename, same as dialogue's (e.g. `{fea1}` in a regular
+    NPC `.msg`) -- never a path. The folder is fixed, not authored: it always resolves
+    to `sound/speech/holodisks/<name>.wav` or `.acm` (searched in that order), the same
+    way dialogue always resolves under `sound/speech/<critter's head name>/<name>`.
 -   Leave the audio field empty (`{}`) for a silent page. Silence is explicit --
     it stops whatever the previous page was playing rather than leaving it running
     under new text.

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -267,6 +267,7 @@ static void pipboyWindowHandleStatus(int userInput);
 static void pipboyWindowRenderQuestLocationList(int a1);
 static void pipboyWindowQuestList(int a1);
 static void pipboyRenderHolodiskText();
+static void pipboyHolodiskUpdatePageAudio(const char* audio);
 static int pipboyWindowRenderHolodiskList(int a1);
 static int _qscmp(const void* a1, const void* a2);
 static void pipboyWindowHandleAutomaps(int a1);
@@ -1696,6 +1697,10 @@ static void pipboyWindowHandleStatus(int userInput)
 
         _holo_flag = 0;
         _holodisk = -1;
+        // Leaving the holodisk detail view for the status list -- stop any
+        // page narration rather than leaving it playing under a screen it no
+        // longer belongs to.
+        speechDelete();
         gPipboyWindowHolodisksCount = 0;
         _view_page_quest = 0;
         _view_page_holodisk = 0;
@@ -2680,6 +2685,37 @@ static void pipboyWindowRenderQuestLocationList(int selectedQuestLocation)
 }
 
 // 0x4988A0
+// Starts or stops the voiced-holodisk speech for the page currently being
+// rendered. `audio` is the raw audio field of the page's first message line
+// (same `{num}{audio}{text}` field VockFloats already reads for dialogue),
+// resolved through speechLoad() exactly like any other speech file under
+// sound/speech/. Gated behind the same VockFloats master switch and
+// VoicedFloats toggle dialogue floats use, so it inherits StrictVanilla and
+// the mod's opt-out without a separate setting.
+//
+// speechLoad() already tears down whatever was previously loaded into
+// gSpeechSound before loading the new file (see its "Delete any existing
+// speech sound" step), so switching pages or holodisks always replaces
+// rather than layers audio. A page with no audio field explicitly calls
+// speechDelete() so a previous page's narration doesn't keep playing under
+// silent text.
+static void pipboyHolodiskUpdatePageAudio(const char* audio)
+{
+    bool voicedHolodisksEnabled = settings.enhancements.vock_floats
+        && !settings.enhancements.strict_vanilla
+        && settings.mod_settings.voiced_floats;
+
+    if (!voicedHolodisksEnabled) {
+        return;
+    }
+
+    if (audio != nullptr && audio[0] != '\0') {
+        speechLoad(audio, GSOUND_LIMIT_AFTER, GSOUND_STREAM, GSOUND_NO_LOOP);
+    } else {
+        speechDelete();
+    }
+}
+
 static void pipboyRenderHolodiskText()
 {
     blitBufferToBuffer(_pipboyFrmImages[PIPBOY_FRM_BACKGROUND].getData() + PIPBOY_WINDOW_WIDTH * PIPBOY_WINDOW_CONTENT_VIEW_Y + PIPBOY_WINDOW_CONTENT_VIEW_X,
@@ -2773,6 +2809,13 @@ static void pipboyRenderHolodiskText()
         const char* text = getmsg(&gPipboyMessageList, &gPipboyMessageListItem, holodiskTextId);
         if (strcmp(text, "**END-DISK**") == 0) {
             break;
+        }
+
+        if (line == 0) {
+            // Page-start line carries the page's audio field, if any. Must
+            // read it before any later getmsg() call in this loop overwrites
+            // gPipboyMessageListItem.
+            pipboyHolodiskUpdatePageAudio(gPipboyMessageListItem.audio);
         }
 
         if (strcmp(text, "**END-PAR**") == 0) {
@@ -4828,7 +4871,10 @@ static void generateHolodiskListReport()
         "   Format: {0}{}{Title}, {1}{}{line1}, ... {99}{}{**END-DISK**}\n"
         "3. BlockKey is a unique identifier for the holodisk within the mod.\n"
         "4. IDs are stable: same ModName + BlockKey gives same base ID.\n"
-        "5. In scripts, set GVAR to non-zero to make holodisk appear.\n");
+        "5. In scripts, set GVAR to non-zero to make holodisk appear.\n"
+        "6. Optional voiced narration: put a filename in a page's first line's\n"
+        "   audio field, e.g. {1}{holodisk\\myquest_intro}{line1}. Resolves via\n"
+        "   sound/speech/, same as other speech. Requires VockFloats+VoicedFloats.\n");
 
     fclose(reportFile);
 }
@@ -4972,6 +5018,11 @@ static int holodiskInit()
 // 0x49A968
 static void holodiskFree()
 {
+    // Safety net for pipboyWindowFree(): stop any holodisk page narration
+    // still playing when the whole Pip-Boy window closes, not just when
+    // backing out to the status list.
+    speechDelete();
+
     if (gHolodiskDescriptions != nullptr) {
         internal_free(gHolodiskDescriptions);
         gHolodiskDescriptions = nullptr;

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -267,7 +267,7 @@ static void pipboyWindowHandleStatus(int userInput);
 static void pipboyWindowRenderQuestLocationList(int a1);
 static void pipboyWindowQuestList(int a1);
 static void pipboyRenderHolodiskText();
-static void pipboyHolodiskUpdatePageAudio(const char* audio);
+static void pipboyHolodiskUpdateAudio(const char* audio);
 static int pipboyWindowRenderHolodiskList(int a1);
 static int _qscmp(const void* a1, const void* a2);
 static void pipboyWindowHandleAutomaps(int a1);
@@ -427,6 +427,11 @@ int gPipboyWindow;
 
 // 0x6644F4
 int _holodisk;
+
+// Index of the holodisk whose audio is currently loaded (-1 if none). Lets
+// pipboyRenderHolodiskText() start a holodisk's narration once, on open,
+// without restarting it on every page turn -- see pipboyHolodiskUpdateAudio().
+static int gPipboyHolodiskAudioIndex = -1;
 
 // 0x6644F8
 int gPipboyWindowButtonCount;
@@ -1697,10 +1702,13 @@ static void pipboyWindowHandleStatus(int userInput)
 
         _holo_flag = 0;
         _holodisk = -1;
-        // Leaving the holodisk detail view for the status list -- stop any
-        // page narration rather than leaving it playing under a screen it no
-        // longer belongs to.
+        // Leaving the holodisk detail view for the status list -- stop the
+        // narration rather than leaving it playing under a screen it no
+        // longer belongs to, and clear the tracker so reopening the same
+        // holodisk later restarts it from the top instead of treating it as
+        // "already playing".
         speechDelete();
+        gPipboyHolodiskAudioIndex = -1;
         gPipboyWindowHolodisksCount = 0;
         _view_page_quest = 0;
         _view_page_holodisk = 0;
@@ -2685,13 +2693,25 @@ static void pipboyWindowRenderQuestLocationList(int selectedQuestLocation)
 }
 
 // 0x4988A0
-// Starts or stops the voiced-holodisk speech for the page currently being
-// rendered. `audio` is the raw audio field of the page's first message line
-// (same `{num}{audio}{text}` field VockFloats already reads for dialogue),
-// resolved through speechLoad() exactly like any other speech file under
-// sound/speech/. Gated behind the same VockFloats master switch and
-// VoicedFloats toggle dialogue floats use, so it inherits StrictVanilla and
-// the mod's opt-out without a separate setting.
+// Starts the voiced-holodisk speech for a holodisk when it's first opened.
+// `audio` is the raw audio field of the holodisk's very first message line
+// (holodisk->description -- same `{num}{audio}{text}` field VockFloats
+// already reads for dialogue), resolved through speechLoad() exactly like
+// any other speech file under sound/speech/. Gated behind the same VockFloats
+// master switch and VoicedFloats toggle dialogue floats use, so it inherits
+// StrictVanilla and the mod's opt-out without a separate setting.
+//
+// This is deliberately one clip for the whole holodisk, not one per page.
+// Pagination (PIPBOY_HOLODISK_LINES_MAX below) is a blind 35-message-ID
+// counter with no idea where a sentence or paragraph ends -- confirmed
+// against real content, e.g. the Hubologist Teachings holodisk's page 1
+// starts mid-sentence ("sightings of Extra-Terrestrial Vehicles..."). Tying
+// a separate clip to each page would mean cutting a recording at whatever
+// arbitrary point the 35-count lands on, and re-cutting it every time the
+// text is edited. One clip that just keeps playing while the reader flips
+// pages has no such seam: pipboyRenderHolodiskText() calls this only when
+// _holodisk changes (see gPipboyHolodiskAudioIndex there), not on every page
+// turn, so speechLoad() is never re-triggered by paging within the same disk.
 //
 // The audio field is a bare filename, same as dialogue's -- see ACERIC.MSG's
 // "{101}{fea1}{...}" or lipsLoad()'s headFileName/audioFileName split. Vanilla
@@ -2699,14 +2719,7 @@ static void pipboyWindowRenderQuestLocationList(int selectedQuestLocation)
 // (there it's the speaking critter's head name, built in lipsLoad() as
 // SOUND\SPEECH\<headFileName>\<audioFileName>). Holodisks have no critter, so
 // the folder is simply fixed to "holodisks" here instead of per-instance.
-//
-// speechLoad() already tears down whatever was previously loaded into
-// gSpeechSound before loading the new file (see its "Delete any existing
-// speech sound" step), so switching pages or holodisks always replaces
-// rather than layers audio. A page with no audio field explicitly calls
-// speechDelete() so a previous page's narration doesn't keep playing under
-// silent text.
-static void pipboyHolodiskUpdatePageAudio(const char* audio)
+static void pipboyHolodiskUpdateAudio(const char* audio)
 {
     bool voicedHolodisksEnabled = settings.enhancements.vock_floats
         && !settings.enhancements.strict_vanilla
@@ -2742,6 +2755,16 @@ static void pipboyRenderHolodiskText()
     gPipboyKeyboardMode = false;
 
     HolodiskDescription* holodisk = &(gHolodiskDescriptions[_holodisk]);
+
+    if (_holodisk != gPipboyHolodiskAudioIndex) {
+        // Newly opened holodisk, not just a page turn within the one whose
+        // narration is already playing -- (re)start it from the top. See
+        // pipboyHolodiskUpdateAudio() for why this is once per holodisk
+        // rather than once per page.
+        getmsg(&gPipboyMessageList, &gPipboyMessageListItem, holodisk->description);
+        pipboyHolodiskUpdateAudio(gPipboyMessageListItem.audio);
+        gPipboyHolodiskAudioIndex = _holodisk;
+    }
 
     int holodiskTextId;
     int linesCount = 0;
@@ -2818,13 +2841,6 @@ static void pipboyRenderHolodiskText()
         const char* text = getmsg(&gPipboyMessageList, &gPipboyMessageListItem, holodiskTextId);
         if (strcmp(text, "**END-DISK**") == 0) {
             break;
-        }
-
-        if (line == 0) {
-            // Page-start line carries the page's audio field, if any. Must
-            // read it before any later getmsg() call in this loop overwrites
-            // gPipboyMessageListItem.
-            pipboyHolodiskUpdatePageAudio(gPipboyMessageListItem.audio);
         }
 
         if (strcmp(text, "**END-PAR**") == 0) {
@@ -4881,10 +4897,11 @@ static void generateHolodiskListReport()
         "3. BlockKey is a unique identifier for the holodisk within the mod.\n"
         "4. IDs are stable: same ModName + BlockKey gives same base ID.\n"
         "5. In scripts, set GVAR to non-zero to make holodisk appear.\n"
-        "6. Optional voiced narration: put a bare filename (no path) in a\n"
-        "   page's first line's audio field, e.g. {1}{myquest_intro}{line1}.\n"
-        "   Resolves to sound/speech/holodisks/myquest_intro.*. Requires\n"
-        "   VockFloats+VoicedFloats.\n");
+        "6. Optional voiced narration: put a bare filename (no path) in the\n"
+        "   holodisk's FIRST line's audio field, e.g. {1}{myquest_intro}{line1}.\n"
+        "   One clip for the whole holodisk, not per page (pages break mid-\n"
+        "   sentence, so per-page audio can't be cut cleanly). Resolves to\n"
+        "   sound/speech/holodisks/myquest_intro.*. Requires VockFloats+VoicedFloats.\n");
 
     fclose(reportFile);
 }
@@ -5028,10 +5045,11 @@ static int holodiskInit()
 // 0x49A968
 static void holodiskFree()
 {
-    // Safety net for pipboyWindowFree(): stop any holodisk page narration
-    // still playing when the whole Pip-Boy window closes, not just when
-    // backing out to the status list.
+    // Safety net for pipboyWindowFree(): stop any holodisk narration still
+    // playing when the whole Pip-Boy window closes, not just when backing
+    // out to the status list.
     speechDelete();
+    gPipboyHolodiskAudioIndex = -1;
 
     if (gHolodiskDescriptions != nullptr) {
         internal_free(gHolodiskDescriptions);

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -2693,6 +2693,13 @@ static void pipboyWindowRenderQuestLocationList(int selectedQuestLocation)
 // VoicedFloats toggle dialogue floats use, so it inherits StrictVanilla and
 // the mod's opt-out without a separate setting.
 //
+// The audio field is a bare filename, same as dialogue's -- see ACERIC.MSG's
+// "{101}{fea1}{...}" or lipsLoad()'s headFileName/audioFileName split. Vanilla
+// never puts a path in a .msg field; the folder always comes from context
+// (there it's the speaking critter's head name, built in lipsLoad() as
+// SOUND\SPEECH\<headFileName>\<audioFileName>). Holodisks have no critter, so
+// the folder is simply fixed to "holodisks" here instead of per-instance.
+//
 // speechLoad() already tears down whatever was previously loaded into
 // gSpeechSound before loading the new file (see its "Delete any existing
 // speech sound" step), so switching pages or holodisks always replaces
@@ -2710,7 +2717,9 @@ static void pipboyHolodiskUpdatePageAudio(const char* audio)
     }
 
     if (audio != nullptr && audio[0] != '\0') {
-        speechLoad(audio, GSOUND_LIMIT_AFTER, GSOUND_STREAM, GSOUND_NO_LOOP);
+        char path[COMPAT_MAX_PATH];
+        snprintf(path, sizeof(path), "holodisks\\%s", audio);
+        speechLoad(path, GSOUND_LIMIT_AFTER, GSOUND_STREAM, GSOUND_NO_LOOP);
     } else {
         speechDelete();
     }
@@ -4872,9 +4881,10 @@ static void generateHolodiskListReport()
         "3. BlockKey is a unique identifier for the holodisk within the mod.\n"
         "4. IDs are stable: same ModName + BlockKey gives same base ID.\n"
         "5. In scripts, set GVAR to non-zero to make holodisk appear.\n"
-        "6. Optional voiced narration: put a filename in a page's first line's\n"
-        "   audio field, e.g. {1}{holodisk\\myquest_intro}{line1}. Resolves via\n"
-        "   sound/speech/, same as other speech. Requires VockFloats+VoicedFloats.\n");
+        "6. Optional voiced narration: put a bare filename (no path) in a\n"
+        "   page's first line's audio field, e.g. {1}{myquest_intro}{line1}.\n"
+        "   Resolves to sound/speech/holodisks/myquest_intro.*. Requires\n"
+        "   VockFloats+VoicedFloats.\n");
 
     fclose(reportFile);
 }


### PR DESCRIPTION
### Description

Holodisk text goes through the generic message-list loader (`getmsg()`/`MessageListItem`). That path already carries a per-line audio field for VockFloats dialogue: the middle slot of the `{num}{audio}{text}` `.msg` triple. Holodisk rendering never read it.

`pipboyRenderHolodiskText()` now reads the audio field on a page's first message line and plays it via `speechLoad()`, the same primitive `endgame.cc` uses for ending narration. Turning a page, opening a different holodisk, or leaving the Pip-Boy stops the current clip. Nothing needs manual cleanup from script or data.

Gated behind the same switches as the rest of VockFloats: `[enhancements] VockFloats` in `fission.cfg`, `[vock-floats] VoicedFloats` in `game.cfg`, off entirely under `StrictVanilla`. With `VockFloats` off, holodisks behave exactly as before: text only.

Applies identically to vanilla holodisks (`data/holodisk.txt` + `PIPBOY.msg`) and mod holodisks (`holodisk_<ModName>_<BlockKey>.msg`); both load through the same `messageListLoadWithBaseOffset()`/`.msg` parser.

Documents the new audio field in `FISSION_Modding_Guide.md` (§11.5.5) and in the in-game holodisk report's usage notes.

Built as a follow-up to #134 (VockFloats); depended on it while that was in review. Now that #134 is merged, this targets `main` directly.

### Reproduction Steps and Savefile (if available)

1. Enable `VockFloats=1` in `fission.cfg` and `VoicedFloats=1` in `game.cfg`'s `[vock-floats]` section.
2. Put an audio filename in the audio field of a holodisk's first message line, e.g. `{1}{myquest_intro}{First line of text}`.
3. Drop the matching file at `sound/speech/holodisks/myquest_intro.wav` (or `.acm`).
4. Open the Pip-Boy and read the holodisk. Narration plays; turning the page or leaving the Pip-Boy stops it.

### Screenshots

N/A. Audio-only change; no visual difference from vanilla holodisk rendering.